### PR TITLE
Increment 1

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ func main() {
 	msrv := service.NewMetricsService(mstor)
 	mhandlers := handler.NewMetricsHandlers(msrv)
 
-	http.HandleFunc("/update", mhandlers.UpdateHandler())
+	http.HandleFunc("/update/", mhandlers.UpdateHandler())
+	log.Printf("Starting server on port %d\n", config.ServerPort)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.ServerPort), nil))
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,21 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/andrewsvn/metrics-overseer/internal/config"
+	"github.com/andrewsvn/metrics-overseer/internal/handler"
+	"github.com/andrewsvn/metrics-overseer/internal/repository"
+	"github.com/andrewsvn/metrics-overseer/internal/service"
+)
+
+func main() {
+	mstor := repository.NewMemStorage()
+	msrv := service.NewMetricsService(mstor)
+	mhandlers := handler.NewMetricsHandlers(msrv)
+
+	http.HandleFunc("/update", mhandlers.UpdateHandler())
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.ServerPort), nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/andrewsvn/metrics-overseer
+
+go 1.24.4

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1,5 +1,5 @@
 package config
 
 const (
-	ServerPort = 8090
+	ServerPort = 8080
 )

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1,0 +1,5 @@
+package config
+
+const (
+	ServerPort = 8090
+)

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -22,6 +22,11 @@ func NewMetricsHandlers(ms *service.MetricsService) *MetricsHandlers {
 
 func (mh *MetricsHandlers) UpdateHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		parts := strings.Split(r.URL.String(), "/")
 		if len(parts) < 4 {
 			http.Error(rw, "metric name/value not specified", http.StatusNotFound)

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/andrewsvn/metrics-overseer/internal/model"
+	"github.com/andrewsvn/metrics-overseer/internal/service"
+)
+
+type MetricsHandlers struct {
+	msrv *service.MetricsService
+}
+
+func NewMetricsHandlers(ms *service.MetricsService) *MetricsHandlers {
+	return &MetricsHandlers{
+		msrv: ms,
+	}
+}
+
+func (mh *MetricsHandlers) UpdateHandler() http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.String(), "/")
+		if len(parts) < 4 {
+			http.Error(rw, "metric name/value not specified", http.StatusNotFound)
+			return
+		}
+
+		mtype := parts[1]
+		id := parts[2]
+		svalue := parts[3]
+		switch mtype {
+		case model.Counter:
+			mh.processCounterValue(rw, id, svalue)
+		case model.Gauge:
+			mh.processGaugeValue(rw, id, svalue)
+		default:
+			http.Error(rw, "invalid metric type", http.StatusBadRequest)
+		}
+	}
+}
+
+func (mh *MetricsHandlers) processCounterValue(
+	rw http.ResponseWriter, id string, svalue string) {
+
+	inc, err := strconv.Atoi(svalue)
+	if err != nil {
+		http.Error(rw, "invalid metric value", http.StatusBadRequest)
+		return
+	}
+	err = mh.msrv.AccumulateCounter(id, int64(inc))
+	if err != nil {
+		if errors.Is(err, model.ErrMethodNotSupported) {
+			http.Error(rw, "invalid metric type", http.StatusBadRequest)
+			return
+		}
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+}
+
+func (mh *MetricsHandlers) processGaugeValue(
+	rw http.ResponseWriter, id string, svalue string) {
+
+	value, err := strconv.ParseFloat(svalue, 64)
+	if err != nil {
+		http.Error(rw, "invalid metric value", http.StatusBadRequest)
+		return
+	}
+	err = mh.msrv.SetGauge(id, value)
+	if err != nil {
+		if errors.Is(err, model.ErrMethodNotSupported) {
+			http.Error(rw, "invalid metric type", http.StatusBadRequest)
+			return
+		}
+		http.Error(rw, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+}

--- a/internal/model/metrics.go
+++ b/internal/model/metrics.go
@@ -1,4 +1,4 @@
-package models
+package model
 
 import (
 	"crypto/md5"

--- a/internal/model/metrics.go
+++ b/internal/model/metrics.go
@@ -11,9 +11,8 @@ const (
 	Gauge   = "gauge"
 )
 
-// Delta и Value объявлены через указатели,
-// чтоы отличать значение "0", от не заданного значения
-// и соответственно не кодировать в структуру.
+// store Delta and Value as pointers to support uninitialized state
+// separated from default value without additional flags
 type Metrics struct {
 	ID    string   `json:"id"`
 	MType string   `json:"type"`

--- a/internal/model/metrics.go
+++ b/internal/model/metrics.go
@@ -1,14 +1,18 @@
 package models
 
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+)
+
 const (
 	Counter = "counter"
 	Gauge   = "gauge"
 )
 
-// NOTE: Не усложняем пример, вводя иерархическую вложенность структур.
-// Органичиваясь плоской моделью.
 // Delta и Value объявлены через указатели,
-// что бы отличать значение "0", от не заданного значения
+// чтоы отличать значение "0", от не заданного значения
 // и соответственно не кодировать в структуру.
 type Metrics struct {
 	ID    string   `json:"id"`
@@ -16,4 +20,80 @@ type Metrics struct {
 	Delta *int64   `json:"delta,omitempty"`
 	Value *float64 `json:"value,omitempty"`
 	Hash  string   `json:"hash,omitempty"`
+}
+
+var (
+	ErrMethodNotSupported = errors.New("access method not supported for metric")
+)
+
+func NewGaugeMetrics(id string) *Metrics {
+	m := &Metrics{
+		ID:    id,
+		MType: Gauge,
+	}
+	m.UpdateHash()
+	return m
+}
+
+func NewCounterMetrics(id string) *Metrics {
+	m := &Metrics{
+		ID:    id,
+		MType: Counter,
+	}
+	m.UpdateHash()
+	return m
+}
+
+func (m *Metrics) Reset() {
+	m.Delta = nil
+	m.Value = nil
+	m.UpdateHash()
+}
+
+func (m Metrics) GetGauge() (*float64, error) {
+	if m.MType != Gauge {
+		return nil, ErrMethodNotSupported
+	}
+	return m.Value, nil
+}
+
+func (m Metrics) GetCounter() (*int64, error) {
+	if m.MType != Counter {
+		return nil, ErrMethodNotSupported
+	}
+	return m.Delta, nil
+}
+
+func (m *Metrics) SetGauge(value float64) error {
+	if m.MType != Gauge {
+		return ErrMethodNotSupported
+	}
+	*m.Value = value
+	m.UpdateHash()
+	return nil
+}
+
+func (m *Metrics) AddCounter(delta int64) error {
+	if m.MType != Gauge {
+		return ErrMethodNotSupported
+	}
+	*m.Delta += delta
+	m.UpdateHash()
+	return nil
+}
+
+func (m *Metrics) UpdateHash() {
+	bytes := fmt.Appendf(nil, "%s#%s", m.ID, m.MType)
+	if m.Delta != nil {
+		bytes = fmt.Appendf(bytes, "#%d", *m.Delta)
+	} else {
+		bytes = fmt.Append(bytes, "#nil")
+	}
+	if m.Value != nil {
+		bytes = fmt.Appendf(bytes, "#%f", *m.Value)
+	} else {
+		bytes = fmt.Append(bytes, "#nil")
+	}
+
+	m.Hash = string(md5.New().Sum(bytes))
 }

--- a/internal/model/metrics.go
+++ b/internal/model/metrics.go
@@ -68,16 +68,21 @@ func (m *Metrics) SetGauge(value float64) error {
 	if m.MType != Gauge {
 		return ErrMethodNotSupported
 	}
-	*m.Value = value
+	m.Value = &value
 	m.UpdateHash()
 	return nil
 }
 
 func (m *Metrics) AddCounter(delta int64) error {
-	if m.MType != Gauge {
+	if m.MType != Counter {
 		return ErrMethodNotSupported
 	}
-	*m.Delta += delta
+
+	if m.Delta == nil {
+		m.Delta = &delta
+	} else {
+		*m.Delta += delta
+	}
 	m.UpdateHash()
 	return nil
 }

--- a/internal/repository/memstorage.go
+++ b/internal/repository/memstorage.go
@@ -1,18 +1,18 @@
 package repository
 
-import models "github.com/andrewsvn/metrics-overseer/internal/model"
+import "github.com/andrewsvn/metrics-overseer/internal/model"
 
 type MemStorage struct {
-	data map[string]*models.Metrics
+	data map[string]*model.Metrics
 }
 
 func NewMemStorage() *MemStorage {
 	return &MemStorage{
-		data: make(map[string]*models.Metrics),
+		data: make(map[string]*model.Metrics),
 	}
 }
 
-func (ms MemStorage) GetGauge(id string) (*float64, error) {
+func (ms *MemStorage) GetGauge(id string) (*float64, error) {
 	m, exists := ms.data[id]
 	if !exists {
 		return nil, nil
@@ -20,16 +20,16 @@ func (ms MemStorage) GetGauge(id string) (*float64, error) {
 	return m.GetGauge()
 }
 
-func (ms MemStorage) SetGauge(id string, value float64) error {
+func (ms *MemStorage) SetGauge(id string, value float64) error {
 	m, exists := ms.data[id]
 	if !exists {
-		m = models.NewGaugeMetrics(id)
+		m = model.NewGaugeMetrics(id)
 		ms.data[id] = m
 	}
 	return m.SetGauge(value)
 }
 
-func (ms MemStorage) GetCounter(id string) (*int64, error) {
+func (ms *MemStorage) GetCounter(id string) (*int64, error) {
 	m, exists := ms.data[id]
 	if !exists {
 		return nil, nil
@@ -37,16 +37,16 @@ func (ms MemStorage) GetCounter(id string) (*int64, error) {
 	return m.GetCounter()
 }
 
-func (ms MemStorage) AddCounter(id string, delta int64) error {
+func (ms *MemStorage) AddCounter(id string, delta int64) error {
 	m, exists := ms.data[id]
 	if !exists {
-		m = models.NewGaugeMetrics(id)
+		m = model.NewGaugeMetrics(id)
 		ms.data[id] = m
 	}
 	return m.AddCounter(delta)
 }
 
-func (ms MemStorage) ResetAll() error {
+func (ms *MemStorage) ResetAll() error {
 	for _, m := range ms.data {
 		m.Reset()
 	}

--- a/internal/repository/memstorage.go
+++ b/internal/repository/memstorage.go
@@ -40,7 +40,7 @@ func (ms *MemStorage) GetCounter(id string) (*int64, error) {
 func (ms *MemStorage) AddCounter(id string, delta int64) error {
 	m, exists := ms.data[id]
 	if !exists {
-		m = model.NewGaugeMetrics(id)
+		m = model.NewCounterMetrics(id)
 		ms.data[id] = m
 	}
 	return m.AddCounter(delta)

--- a/internal/repository/memstorage.go
+++ b/internal/repository/memstorage.go
@@ -1,0 +1,54 @@
+package repository
+
+import models "github.com/andrewsvn/metrics-overseer/internal/model"
+
+type MemStorage struct {
+	data map[string]*models.Metrics
+}
+
+func NewMemStorage() *MemStorage {
+	return &MemStorage{
+		data: make(map[string]*models.Metrics),
+	}
+}
+
+func (ms MemStorage) GetGauge(id string) (*float64, error) {
+	m, exists := ms.data[id]
+	if !exists {
+		return nil, nil
+	}
+	return m.GetGauge()
+}
+
+func (ms MemStorage) SetGauge(id string, value float64) error {
+	m, exists := ms.data[id]
+	if !exists {
+		m = models.NewGaugeMetrics(id)
+		ms.data[id] = m
+	}
+	return m.SetGauge(value)
+}
+
+func (ms MemStorage) GetCounter(id string) (*int64, error) {
+	m, exists := ms.data[id]
+	if !exists {
+		return nil, nil
+	}
+	return m.GetCounter()
+}
+
+func (ms MemStorage) AddCounter(id string, delta int64) error {
+	m, exists := ms.data[id]
+	if !exists {
+		m = models.NewGaugeMetrics(id)
+		ms.data[id] = m
+	}
+	return m.AddCounter(delta)
+}
+
+func (ms MemStorage) ResetAll() error {
+	for _, m := range ms.data {
+		m.Reset()
+	}
+	return nil
+}

--- a/internal/repository/storage.go
+++ b/internal/repository/storage.go
@@ -1,0 +1,15 @@
+package repository
+
+// all methods have an option to return error in case
+// when some internal storage problem occurs
+// or method is unsupported for chosen metric
+// error is not returned if data is not found in get methods
+type Storage interface {
+	GetGauge(id string) (*float64, error)
+	SetGauge(id string, value float64) error
+
+	GetCounter(id string) (*int64, error)
+	AddCounter(id string, delta int64) error
+
+	ResetAll() error
+}

--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -1,0 +1,21 @@
+package service
+
+import "github.com/andrewsvn/metrics-overseer/internal/repository"
+
+type MetricsService struct {
+	storage repository.Storage
+}
+
+func NewMetricsService(st repository.Storage) *MetricsService {
+	return &MetricsService{
+		storage: st,
+	}
+}
+
+func (ms *MetricsService) AccumulateCounter(id string, inc int64) error {
+	return ms.storage.AddCounter(id, inc)
+}
+
+func (ms *MetricsService) SetGauge(id string, val float64) error {
+	return ms.storage.SetGauge(id, val)
+}


### PR DESCRIPTION
New metrics service is created (only update operation currently supported)

Changes include:
- memory-based storage for metrics of Counter (int64 incremental) and Gauge (float64) types
- access methods for querying and updating metrics values in the storage
- service layer encapsulating storage (no additional logic)
- handler for HTTP POST request /update/{type}/{id}/{value} - including validations and calling service methods

No unit tests and metrics checks implemented yet.