### PR TITLE
Iteration 5

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	cfg := agentcfg.ReadFromCLArgs()
+	cfg := agentcfg.Read()
 	a, err := agent.NewAgent(cfg)
 	if err != nil {
 		log.Fatalf("Can't initialize agent: %v", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,7 +15,7 @@ func main() {
 }
 
 func run() error {
-	cfg := servercfg.ReadFromCLArgs()
+	cfg := servercfg.Read()
 
 	mstor := repository.NewMemStorage()
 	msrv := service.NewMetricsService(mstor)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
+github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -11,22 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type TestSender struct {
+type testSender struct {
 	t          *testing.T
 	callTotal  int
 	cntCalls   map[string]int64
 	gaugeCalls map[string]float64
 }
 
-func NewTestSender(t *testing.T) *TestSender {
-	return &TestSender{
+func newTestSender(t *testing.T) *testSender {
+	return &testSender{
 		t:          t,
 		cntCalls:   make(map[string]int64),
 		gaugeCalls: make(map[string]float64),
 	}
 }
 
-func (ts *TestSender) MetricSendFunc() sender.MetricSendFunc {
+func (ts *testSender) MetricSendFunc() sender.MetricSendFunc {
 	return func(id, mtype, value string) error {
 		ts.callTotal += 1
 		switch mtype {
@@ -46,7 +46,7 @@ func (ts *TestSender) MetricSendFunc() sender.MetricSendFunc {
 }
 
 func TestAgentAccumulators(t *testing.T) {
-	a, err := NewAgent(agentcfg.DefaultConfig())
+	a, err := NewAgent(agentcfg.Read())
 	require.NoError(t, err)
 
 	assert.Empty(t, a.accums)
@@ -64,7 +64,7 @@ func TestAgentAccumulators(t *testing.T) {
 }
 
 func TestAgentPolling(t *testing.T) {
-	a, err := NewAgent(agentcfg.DefaultConfig())
+	a, err := NewAgent(agentcfg.Read())
 	require.NoError(t, err)
 
 	a.execPoll()
@@ -76,7 +76,7 @@ func TestAgentPolling(t *testing.T) {
 }
 
 func TestAgentReporting(t *testing.T) {
-	a, err := NewAgent(agentcfg.DefaultConfig())
+	a, err := NewAgent(agentcfg.Read())
 	require.NoError(t, err)
 
 	a.storeCounterMetric("cnt1", 1)
@@ -89,7 +89,7 @@ func TestAgentReporting(t *testing.T) {
 	a.storeGaugeMetric("gauge1", 1.75)
 	a.storeGaugeMetric("gauge2", 3.14)
 
-	ts := NewTestSender(t)
+	ts := newTestSender(t)
 	a.sndr = ts
 	a.execReport()
 

--- a/internal/config/agentcfg/config.go
+++ b/internal/config/agentcfg/config.go
@@ -3,6 +3,7 @@ package agentcfg
 import (
 	"flag"
 	"fmt"
+	"github.com/caarlos0/env/v6"
 )
 
 const (
@@ -12,23 +13,16 @@ const (
 )
 
 type Config struct {
-	ServerAddr        string
-	PollIntervalSec   int
-	ReportIntervalSec int
+	ServerAddr        string `env:"ADDRESS"`
+	PollIntervalSec   int    `env:"POLL_INTERVAL"`
+	ReportIntervalSec int    `env:"REPORT_INTERVAL"`
 }
 
-func DefaultConfig() *Config {
-	return &Config{
-		ServerAddr:        defaultServerAddr,
-		PollIntervalSec:   defaultPollIntervalSec,
-		ReportIntervalSec: defaultReportIntervalSec,
-	}
-}
-
-func ReadFromCLArgs() *Config {
+func Read() *Config {
 	cfg := &Config{}
 	cfg.bindFlags()
 	flag.Parse()
+	_ = env.Parse(cfg)
 	return cfg
 }
 

--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -3,6 +3,7 @@ package servercfg
 import (
 	"flag"
 	"fmt"
+	"github.com/caarlos0/env/v6"
 )
 
 const (
@@ -10,22 +11,18 @@ const (
 )
 
 type Config struct {
-	Addr string
+	Addr string `env:"ADDRESS"`
 }
 
-func DefaultConfig() *Config {
-	return &Config{
-		Addr: defaultAddr,
-	}
-}
-
-func ReadFromCLArgs() *Config {
+func Read() *Config {
 	cfg := &Config{}
 	cfg.bindFlags()
 	flag.Parse()
+	_ = env.Parse(cfg)
 	return cfg
 }
 
 func (cfg *Config) bindFlags() {
-	flag.StringVar(&cfg.Addr, "a", defaultAddr, fmt.Sprintf("server address in form of host:port (default: %s)", defaultAddr))
+	flag.StringVar(&cfg.Addr, "a", defaultAddr,
+		fmt.Sprintf("server address in form of host:port (default: %s)", defaultAddr))
 }


### PR DESCRIPTION
Priority config values for server and agent can be now set from the corresponding environment variables:
server:
- server address from ADDRESS
agent:
- server address from ADDRESS
- poll interval, sec from POLL_INTERVAL
- report interval, sec from REPORT_INTERVAL

Environment variables have highest priority - if not set, flags are checked next, and default values in case when neither is specified.