### PR TITLE
Increment 9

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	cfg := agentcfg.ReadFromCLArgs()
+	cfg := agentcfg.Read()
 	a, err := agent.NewAgent(cfg)
 	if err != nil {
 		log.Fatalf("Can't initialize agent: %v", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/andrewsvn/metrics-overseer/internal/logging"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/andrewsvn/metrics-overseer/internal/config/servercfg"
 	"github.com/andrewsvn/metrics-overseer/internal/handler"
@@ -29,6 +30,7 @@ func run() error {
 
 	r := mhandlers.GetRouter()
 
-	logger.Info(fmt.Sprintf("Starting server on %s\n", cfg.Addr))
-	return http.ListenAndServe(cfg.Addr, r)
+	addr := strings.Trim(cfg.Addr, "\"")
+	logger.Info(fmt.Sprintf("Starting server on %s\n", addr))
+	return http.ListenAndServe(addr, r)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,7 +15,7 @@ func main() {
 }
 
 func run() error {
-	cfg := servercfg.ReadFromCLArgs()
+	cfg := servercfg.Read()
 
 	mstor := repository.NewMemStorage()
 	msrv := service.NewMetricsService(mstor)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,7 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,15 @@ module github.com/andrewsvn/metrics-overseer
 go 1.24.4
 
 require (
+	github.com/caarlos0/env/v6 v6.10.1
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/zap v1.27.0
 )
 
 require (
-	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
+github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -122,7 +122,7 @@ func (a *Agent) report(tc <-chan time.Time) {
 func (a *Agent) execReport() {
 	a.logger.Info("Reporting metrics to server")
 	for name, ma := range a.accums {
-		err := ma.ExtractAndSend(a.sndr.MetricSendFunc())
+		err := ma.ExtractAndSend(a.sndr.StructSendFunc())
 		if err != nil {
 			a.logger.Error(fmt.Sprintf("unable to send metric %s to server", name))
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -32,7 +33,8 @@ func NewAgent(cfg *agentcfg.Config) (*Agent, error) {
 		return nil, fmt.Errorf("can't initialize logger: %w", err)
 	}
 
-	sndr, err := sender.NewRestSender(cfg.ServerAddr, logger)
+	serverAddr := strings.Trim(cfg.ServerAddr, "\"")
+	sndr, err := sender.NewRestSender(serverAddr, logger)
 	if err != nil {
 		return nil, fmt.Errorf("can't construct agent from config: %w", err)
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -11,22 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type TestSender struct {
+type testSender struct {
 	t          *testing.T
 	callTotal  int
 	cntCalls   map[string]int64
 	gaugeCalls map[string]float64
 }
 
-func NewTestSender(t *testing.T) *TestSender {
-	return &TestSender{
+func newTestSender(t *testing.T) *testSender {
+	return &testSender{
 		t:          t,
 		cntCalls:   make(map[string]int64),
 		gaugeCalls: make(map[string]float64),
 	}
 }
 
-func (ts *TestSender) MetricSendFunc() sender.MetricSendFunc {
+func (ts *testSender) MetricSendFunc() sender.MetricSendFunc {
 	return func(id, mtype, value string) error {
 		ts.callTotal += 1
 		switch mtype {
@@ -46,7 +46,7 @@ func (ts *TestSender) MetricSendFunc() sender.MetricSendFunc {
 }
 
 func TestAgentAccumulators(t *testing.T) {
-	a, err := NewAgent(agentcfg.DefaultConfig())
+	a, err := NewAgent(agentcfg.Read())
 	require.NoError(t, err)
 
 	assert.Empty(t, a.accums)
@@ -64,7 +64,7 @@ func TestAgentAccumulators(t *testing.T) {
 }
 
 func TestAgentPolling(t *testing.T) {
-	a, err := NewAgent(agentcfg.DefaultConfig())
+	a, err := NewAgent(agentcfg.Read())
 	require.NoError(t, err)
 
 	a.execPoll()
@@ -76,7 +76,7 @@ func TestAgentPolling(t *testing.T) {
 }
 
 func TestAgentReporting(t *testing.T) {
-	a, err := NewAgent(agentcfg.DefaultConfig())
+	a, err := NewAgent(agentcfg.Read())
 	require.NoError(t, err)
 
 	a.storeCounterMetric("cnt1", 1)
@@ -89,7 +89,7 @@ func TestAgentReporting(t *testing.T) {
 	a.storeGaugeMetric("gauge1", 1.75)
 	a.storeGaugeMetric("gauge2", 3.14)
 
-	ts := NewTestSender(t)
+	ts := newTestSender(t)
 	a.sndr = ts
 	a.execReport()
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -46,7 +46,7 @@ func (ts *testSender) MetricSendFunc() sender.MetricSendFunc {
 }
 
 func TestAgentAccumulators(t *testing.T) {
-	a, err := NewAgent(agentcfg.Read())
+	a, err := NewAgent(agentcfg.Default())
 	require.NoError(t, err)
 
 	assert.Empty(t, a.accums)
@@ -64,7 +64,7 @@ func TestAgentAccumulators(t *testing.T) {
 }
 
 func TestAgentPolling(t *testing.T) {
-	a, err := NewAgent(agentcfg.Read())
+	a, err := NewAgent(agentcfg.Default())
 	require.NoError(t, err)
 
 	a.execPoll()
@@ -76,7 +76,7 @@ func TestAgentPolling(t *testing.T) {
 }
 
 func TestAgentReporting(t *testing.T) {
-	a, err := NewAgent(agentcfg.Read())
+	a, err := NewAgent(agentcfg.Default())
 	require.NoError(t, err)
 
 	a.storeCounterMetric("cnt1", 1)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -26,7 +26,7 @@ func newTestSender(t *testing.T) *testSender {
 	}
 }
 
-func (ts *testSender) MetricSendFunc() sender.MetricSendFunc {
+func (ts *testSender) ValueSendFunc() sender.MetricValueSendFunc {
 	return func(id, mtype, value string) error {
 		ts.callTotal += 1
 		switch mtype {
@@ -40,6 +40,25 @@ func (ts *testSender) MetricSendFunc() sender.MetricSendFunc {
 			ts.gaugeCalls[id] = fval
 		default:
 			assert.Fail(ts.t, "Incorrect metric type passed: "+mtype)
+		}
+		return nil
+	}
+}
+
+func (ts *testSender) StructSendFunc() sender.MetricStructSendFunc {
+	return func(metric *model.Metrics) error {
+		ts.callTotal += 1
+		switch metric.MType {
+		case model.Counter:
+			assert.NotNil(ts.t, metric.Delta)
+			assert.Nil(ts.t, metric.Value)
+			ts.cntCalls[metric.ID] = *metric.Delta
+		case model.Gauge:
+			assert.NotNil(ts.t, metric.Value)
+			assert.Nil(ts.t, metric.Delta)
+			ts.gaugeCalls[metric.ID] = *metric.Value
+		default:
+			assert.Fail(ts.t, "Incorrect metric type passed: "+metric.MType)
 		}
 		return nil
 	}

--- a/internal/agent/metrics/accumulator.go
+++ b/internal/agent/metrics/accumulator.go
@@ -2,8 +2,6 @@ package metrics
 
 import (
 	"fmt"
-	"strconv"
-
 	"github.com/andrewsvn/metrics-overseer/internal/agent/sender"
 	"github.com/andrewsvn/metrics-overseer/internal/model"
 )
@@ -56,7 +54,7 @@ func (ma *MetricAccumulator) AccumulateGauge(value float64) error {
 	return nil
 }
 
-func (ma *MetricAccumulator) ExtractAndSend(sendfunc sender.MetricSendFunc) error {
+func (ma *MetricAccumulator) ExtractAndSend(sendfunc sender.MetricStructSendFunc) error {
 	switch ma.MType {
 	case model.Counter:
 		return ma.extractAndSendCounter(sendfunc)
@@ -67,13 +65,13 @@ func (ma *MetricAccumulator) ExtractAndSend(sendfunc sender.MetricSendFunc) erro
 	}
 }
 
-func (ma *MetricAccumulator) extractAndSendCounter(sendfunc sender.MetricSendFunc) error {
+func (ma *MetricAccumulator) extractAndSendCounter(sendfunc sender.MetricStructSendFunc) error {
 	if ma.Delta == nil {
 		return nil
 	}
 
 	total := *ma.Delta
-	err := sendfunc(ma.ID, ma.MType, strconv.FormatInt(total, 10))
+	err := sendfunc(model.NewMetrics(ma.ID, ma.MType, ma.Delta, nil))
 	if err != nil {
 		return fmt.Errorf("error sending accumulated metric id=%s value=%d to server: %w", ma.ID, total, err)
 	}
@@ -87,7 +85,7 @@ func (ma *MetricAccumulator) extractAndSendCounter(sendfunc sender.MetricSendFun
 	return nil
 }
 
-func (ma *MetricAccumulator) extractAndSendGauge(sendfunc sender.MetricSendFunc) error {
+func (ma *MetricAccumulator) extractAndSendGauge(sendfunc sender.MetricStructSendFunc) error {
 	if len(ma.Values) == 0 {
 		return nil
 	}
@@ -100,7 +98,7 @@ func (ma *MetricAccumulator) extractAndSendGauge(sendfunc sender.MetricSendFunc)
 	}
 	total /= float64(count)
 
-	err := sendfunc(ma.ID, ma.MType, strconv.FormatFloat(total, 'f', 6, 64))
+	err := sendfunc(model.NewMetrics(ma.ID, ma.MType, nil, &total))
 	if err != nil {
 		return fmt.Errorf("error sending accumulated metric id=%s value=%f to server: %w", ma.ID, total, err)
 	}

--- a/internal/agent/metrics/accumulator_test.go
+++ b/internal/agent/metrics/accumulator_test.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/andrewsvn/metrics-overseer/internal/model"
@@ -21,22 +20,23 @@ func TestCounterAccumulator(t *testing.T) {
 	err = cntAcc.AccumulateGauge(100)
 	assert.ErrorAs(t, err, &model.ErrIncorrectAccess)
 
-	cntAcc.AccumulateCounter(2)
-	cntAcc.AccumulateCounter(3)
+	_ = cntAcc.AccumulateCounter(2)
+	_ = cntAcc.AccumulateCounter(3)
 	assert.Equal(t, int64(6), *cntAcc.Delta)
 
-	err = cntAcc.ExtractAndSend(func(id, mtype, value string) error {
-		assert.Equal(t, "cnt", id)
-		assert.Equal(t, model.Counter, mtype)
-		assert.Equal(t, "6", value)
+	err = cntAcc.ExtractAndSend(func(metric *model.Metrics) error {
+		assert.Equal(t, "cnt", metric.ID)
+		assert.Equal(t, model.Counter, metric.MType)
+		assert.Equal(t, int64(6), *metric.Delta)
+		assert.Nil(t, metric.Value)
 		return nil
 	})
 	require.NoError(t, err)
 	assert.Nil(t, cntAcc.Delta)
 
-	cntAcc.AccumulateCounter(5)
-	err = cntAcc.ExtractAndSend(func(id, mtype, value string) error {
-		assert.Equal(t, "5", value)
+	_ = cntAcc.AccumulateCounter(5)
+	err = cntAcc.ExtractAndSend(func(metric *model.Metrics) error {
+		assert.Equal(t, int64(5), *metric.Delta)
 		return fmt.Errorf("sender error")
 	})
 	assert.Error(t, err)
@@ -58,27 +58,24 @@ func TestGaugeAccumulator(t *testing.T) {
 	err = gaAcc.AccumulateGauge(1.5)
 	require.NoError(t, err)
 
-	gaAcc.AccumulateGauge(3.0)
-	gaAcc.AccumulateGauge(4.5)
+	_ = gaAcc.AccumulateGauge(3.0)
+	_ = gaAcc.AccumulateGauge(4.5)
 	assert.Equal(t, 3, len(gaAcc.Values))
 
-	err = gaAcc.ExtractAndSend(func(id, mtype, value string) error {
-		assert.Equal(t, "mem", id)
-		assert.Equal(t, model.Gauge, mtype)
-		fval, err := strconv.ParseFloat(value, 64)
-		require.NoError(t, err)
-		assert.Equal(t, 3.0, fval)
+	err = gaAcc.ExtractAndSend(func(metric *model.Metrics) error {
+		assert.Equal(t, "mem", metric.ID)
+		assert.Equal(t, model.Gauge, metric.MType)
+		assert.Equal(t, 3.0, *metric.Value)
+		assert.Nil(t, metric.Delta)
 		return nil
 	})
 	require.NoError(t, err)
 	assert.Empty(t, gaAcc.Values)
 
-	gaAcc.AccumulateGauge(2.0)
-	gaAcc.AccumulateGauge(-2.5)
-	err = gaAcc.ExtractAndSend(func(id, mtype, value string) error {
-		fval, err := strconv.ParseFloat(value, 64)
-		require.NoError(t, err)
-		assert.Equal(t, -0.25, fval)
+	_ = gaAcc.AccumulateGauge(2.0)
+	_ = gaAcc.AccumulateGauge(-2.5)
+	err = gaAcc.ExtractAndSend(func(metric *model.Metrics) error {
+		assert.Equal(t, -0.25, *metric.Value)
 		return fmt.Errorf("sender error")
 	})
 	assert.Error(t, err)

--- a/internal/agent/sender/address.go
+++ b/internal/agent/sender/address.go
@@ -7,6 +7,10 @@ import (
 )
 
 func enrichServerAddress(addr string) (string, error) {
+	// regexp to accept server address in 3 possible formats:
+	// - protocol://host:port
+	// - host:port
+	// - :port
 	re, err := regexp.Compile(`^(?:((?:http|https)://)?([^:]+))?(:\d+)$`)
 	if err != nil {
 		return "", fmt.Errorf("can't compile regexp for network address enrichment: %w", err)

--- a/internal/agent/sender/rest.go
+++ b/internal/agent/sender/rest.go
@@ -41,9 +41,7 @@ func (rs RestSender) MetricSendFunc() MetricSendFunc {
 		if err != nil {
 			return fmt.Errorf("error sending request to server %s: %w", rs.addr, err)
 		}
-		defer func(Body io.ReadCloser) {
-			_ = Body.Close()
-		}(resp.Body)
+		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/internal/agent/sender/rest.go
+++ b/internal/agent/sender/rest.go
@@ -1,7 +1,10 @@
 package sender
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"github.com/andrewsvn/metrics-overseer/internal/model"
 	"go.uber.org/zap"
 	"io"
 	"net/http"
@@ -32,36 +35,56 @@ func NewRestSender(addr string, logger *zap.Logger) (*RestSender, error) {
 	return rs, nil
 }
 
-func (rs RestSender) MetricSendFunc() MetricSendFunc {
+func (rs RestSender) ValueSendFunc() MetricValueSendFunc {
 	return func(id string, mtype string, value string) error {
-		req, err := http.NewRequest(http.MethodPost, rs.composePostMetricURL(id, mtype, value), nil)
+		req, err := http.NewRequest(http.MethodPost, rs.composePostMetricByPathURL(id, mtype, value), nil)
 		if err != nil {
 			return fmt.Errorf("can't construct metric send request: %w", err)
 		}
-
 		req.Header.Add("Content-Type", "text/plain")
-		resp, err := rs.cl.Do(req)
-		if err != nil {
-			return fmt.Errorf("error sending request to server %s: %w", rs.addr, err)
-		}
-		defer func() {
-			err := resp.Body.Close()
-			if err != nil {
-				rs.logger.Error("error closing response body", zap.Error(err))
-			}
-		}()
 
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("can't read response body from metrics send operation: %w", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("error received from metric server (%d) %s", resp.StatusCode, body)
-		}
-		return nil
+		return rs.sendRequest(req)
 	}
 }
 
-func (rs RestSender) composePostMetricURL(id string, mtype string, value string) string {
+func (rs RestSender) StructSendFunc() MetricStructSendFunc {
+	return func(metric *model.Metrics) error {
+		body, err := json.Marshal(metric)
+		if err != nil {
+			return fmt.Errorf("can't construct metric send request: %w", err)
+		}
+		req, err := http.NewRequest(http.MethodPost, rs.addr+"/update", bytes.NewBufferString(string(body)))
+		if err != nil {
+			return fmt.Errorf("can't construct metric send request: %w", err)
+		}
+		req.Header.Add("Content-Type", "text/plain")
+
+		return rs.sendRequest(req)
+	}
+}
+
+func (rs RestSender) sendRequest(req *http.Request) error {
+	resp, err := rs.cl.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request to server %s: %w", rs.addr, err)
+	}
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			rs.logger.Error("error closing response body", zap.Error(err))
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("can't read response body from metrics send operation: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error received from metric server (%d) %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+func (rs RestSender) composePostMetricByPathURL(id string, mtype string, value string) string {
 	return fmt.Sprintf("%s/update/%s/%s/%s", rs.addr, mtype, id, value)
 }

--- a/internal/agent/sender/rest.go
+++ b/internal/agent/sender/rest.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go.uber.org/zap"
 	"io"
-	"log"
 	"net/http"
 )
 
@@ -15,7 +14,7 @@ type RestSender struct {
 	// and to enable connection reuse for sequential server calls
 	cl *http.Client
 
-	l *zap.Logger
+	logger *zap.Logger
 }
 
 func NewRestSender(addr string, logger *zap.Logger) (*RestSender, error) {
@@ -24,11 +23,11 @@ func NewRestSender(addr string, logger *zap.Logger) (*RestSender, error) {
 		return nil, fmt.Errorf("can't enrich address for sender to a proper format: %w", err)
 	}
 
-	log.Printf("[INFO] Server address for sending reports: %s", enrichedAddr)
+	logger.Info(fmt.Sprintf("Sender address for sending reports: %s", enrichedAddr))
 	rs := &RestSender{
-		addr: enrichedAddr,
-		cl:   &http.Client{},
-		l:    logger,
+		addr:   enrichedAddr,
+		cl:     &http.Client{},
+		logger: logger,
 	}
 	return rs, nil
 }
@@ -48,7 +47,7 @@ func (rs RestSender) MetricSendFunc() MetricSendFunc {
 		defer func() {
 			err := resp.Body.Close()
 			if err != nil {
-				rs.l.Error("error closing response body", zap.Error(err))
+				rs.logger.Error("error closing response body", zap.Error(err))
 			}
 		}()
 

--- a/internal/agent/sender/rest.go
+++ b/internal/agent/sender/rest.go
@@ -10,7 +10,7 @@ import (
 type RestSender struct {
 	addr string
 
-	// we use custom http client here for further customization
+	// we use a custom http client here for further customization
 	// and to enable connection reuse for sequential server calls
 	cl *http.Client
 }
@@ -41,7 +41,9 @@ func (rs RestSender) MetricSendFunc() MetricSendFunc {
 		if err != nil {
 			return fmt.Errorf("error sending request to server %s: %w", rs.addr, err)
 		}
-		defer resp.Body.Close()
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(resp.Body)
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/internal/agent/sender/rest_test.go
+++ b/internal/agent/sender/rest_test.go
@@ -21,6 +21,6 @@ func TestRestSender(t *testing.T) {
 	rs, err := NewRestSender("localhost:8080", logger)
 	require.NoError(t, err)
 
-	url := rs.composePostMetricURL("cnt1", model.Counter, "10")
+	url := rs.composePostMetricByPathURL("cnt1", model.Counter, "10")
 	assert.Equal(t, "http://localhost:8080/update/counter/cnt1/10", url)
 }

--- a/internal/agent/sender/rest_test.go
+++ b/internal/agent/sender/rest_test.go
@@ -1,6 +1,7 @@
 package sender
 
 import (
+	"github.com/andrewsvn/metrics-overseer/internal/logging"
 	"testing"
 
 	"github.com/andrewsvn/metrics-overseer/internal/model"
@@ -9,13 +10,15 @@ import (
 )
 
 func TestRestSender(t *testing.T) {
-	_, err := NewRestSender("http:localhost:8080")
+	logger, _ := logging.NewZapLogger("info")
+
+	_, err := NewRestSender("http:localhost:8080", logger)
 	require.Error(t, err)
 
-	_, err = NewRestSender("http://localhost:8o8o")
+	_, err = NewRestSender("http://localhost:8o8o", logger)
 	require.Error(t, err)
 
-	rs, err := NewRestSender("localhost:8080")
+	rs, err := NewRestSender("localhost:8080", logger)
 	require.NoError(t, err)
 
 	url := rs.composePostMetricURL("cnt1", model.Counter, "10")

--- a/internal/agent/sender/sender.go
+++ b/internal/agent/sender/sender.go
@@ -1,7 +1,13 @@
 package sender
 
-type MetricSendFunc func(id string, mtype string, value string) error
+import (
+	"github.com/andrewsvn/metrics-overseer/internal/model"
+)
+
+type MetricValueSendFunc func(id string, mtype string, value string) error
+type MetricStructSendFunc func(metric *model.Metrics) error
 
 type MetricSender interface {
-	MetricSendFunc() MetricSendFunc
+	ValueSendFunc() MetricValueSendFunc
+	StructSendFunc() MetricStructSendFunc
 }

--- a/internal/compress/compressor.go
+++ b/internal/compress/compressor.go
@@ -1,0 +1,35 @@
+package compress
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type Compressor struct {
+	engines []WriteEngine
+	logger  *zap.Logger
+}
+
+func NewCompressor(l *zap.Logger, engines ...WriteEngine) *Compressor {
+	return &Compressor{
+		engines: engines,
+		logger:  l,
+	}
+}
+
+func (c *Compressor) CreateCompressWriter(w http.ResponseWriter, r *http.Request) (CompressedResponseWriter, error) {
+	for _, wEngine := range c.engines {
+		if wEngine.Applicable(r.Header) {
+			c.logger.Debug("Compression engine chosen for response writing",
+				zap.String("name", wEngine.Name()))
+			crw, err := wEngine.NewResponseWriter(w, 0)
+			if err != nil {
+				c.logger.Error("Error creating compress writer", zap.Error(err))
+				return nil, fmt.Errorf("error creating compress writer: %w", err)
+			}
+			return crw, nil
+		}
+	}
+	return nil, nil
+}

--- a/internal/compress/decompressor.go
+++ b/internal/compress/decompressor.go
@@ -1,0 +1,31 @@
+package compress
+
+import (
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+)
+
+type Decompressor struct {
+	engines []ReadEngine
+	logger  *zap.Logger
+}
+
+func NewDecompressor(l *zap.Logger, engines ...ReadEngine) *Decompressor {
+	return &Decompressor{
+		engines: engines,
+		logger:  l,
+	}
+}
+
+func (d *Decompressor) ReadRequestBody(r *http.Request) ([]byte, error) {
+	for _, engine := range d.engines {
+		if engine.Applicable(r.Header) {
+			d.logger.Debug("Decompress reader chosen for request body", zap.String("name", engine.Name()))
+			b, err := engine.ReadAll(r.Body)
+			return b, err
+		}
+	}
+	b, err := io.ReadAll(r.Body)
+	return b, err
+}

--- a/internal/compress/engine.go
+++ b/internal/compress/engine.go
@@ -1,0 +1,57 @@
+package compress
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+type CompressedResponseWriter interface {
+	http.ResponseWriter
+	Close() error
+}
+
+type WriteEngine interface {
+	Name() string
+
+	// Applicable determines if engine can be used to write response body
+	Applicable(header http.Header) bool
+	// NewResponseWriter returns wrapped ResponseWriter to use in underlying handlers
+	NewResponseWriter(w http.ResponseWriter, level int) (CompressedResponseWriter, error)
+
+	// WriteFlushed compresses source data into new buffer and closes the writer to finalize write operation
+	WriteFlushed(data []byte, level int) ([]byte, error)
+	// SetContentEncoding adds an http header to indicate that content is compressed by a certain algorithm
+	SetContentEncoding(header http.Header)
+}
+
+type ReadEngine interface {
+	Name() string
+
+	// Applicable determines if engine can be used to read request body
+	Applicable(header http.Header) bool
+	// ReadAll extracts all data from reader decompressing it by underlying algorithm
+	ReadAll(r io.Reader) ([]byte, error)
+}
+
+func checkAcceptEncodingIncludes(header http.Header, encodings ...string) bool {
+	acceptEncoding := header.Get("Accept-Encoding")
+	for _, acceptable := range strings.Split(acceptEncoding, ",") {
+		for _, encoding := range encodings {
+			if encoding == strings.TrimSpace(acceptable) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func checkContentEncoding(header http.Header, encodings ...string) bool {
+	contentEncoding := header.Get("Content-Encoding")
+	for _, encoding := range encodings {
+		if encoding == contentEncoding {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/compress/gzip.go
+++ b/internal/compress/gzip.go
@@ -1,0 +1,112 @@
+package compress
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	gzipEncoding = "gzip"
+)
+
+type GzipWriteEngine struct{}
+
+func NewGzipWriteEngine() *GzipWriteEngine {
+	return &GzipWriteEngine{}
+}
+
+func (gwe *GzipWriteEngine) Name() string {
+	return gzipEncoding
+}
+
+func (gwe *GzipWriteEngine) Applicable(header http.Header) bool {
+	return checkAcceptEncodingIncludes(header, gzipEncoding)
+}
+
+func (gwe *GzipWriteEngine) NewResponseWriter(w http.ResponseWriter, level int) (CompressedResponseWriter, error) {
+	gw, err := gzip.NewWriterLevel(w, normalizeGzipLevel(level))
+	if err != nil {
+		return nil, fmt.Errorf("error intitalizing gzip writer: %w", err)
+	}
+	return &gzipResponseWriter{w, gw}, nil
+}
+
+func (gwe *GzipWriteEngine) WriteFlushed(data []byte, level int) ([]byte, error) {
+	var b bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&b, normalizeGzipLevel(level))
+	if err != nil {
+		return nil, fmt.Errorf("error intitalizing gzip writer: %w", err)
+	}
+	_, err = gw.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("error writing to gzip writer: %w", err)
+	}
+	err = gw.Close()
+	if err != nil {
+		return nil, fmt.Errorf("error compressing data with gzip: %w", err)
+	}
+	return b.Bytes(), nil
+}
+
+func (gwe *GzipWriteEngine) SetContentEncoding(header http.Header) {
+	header.Set("Content-Encoding", gzipEncoding)
+}
+
+type GzipReadEngine struct{}
+
+func NewGzipReadEngine() *GzipReadEngine {
+	return &GzipReadEngine{}
+}
+
+func (gre *GzipReadEngine) Name() string {
+	return gzipEncoding
+}
+
+func (gre *GzipReadEngine) Applicable(header http.Header) bool {
+	return checkContentEncoding(header, gzipEncoding)
+}
+
+func (gre *GzipReadEngine) ReadAll(r io.Reader) ([]byte, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing gzip reader: %w", err)
+	}
+
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		return nil, fmt.Errorf("error reading gzipped data: %w", err)
+	}
+	return data, nil
+}
+
+func normalizeGzipLevel(level int) int {
+	if level <= 0 {
+		return gzip.DefaultCompression
+	}
+	if level > gzip.BestCompression {
+		return gzip.BestCompression
+	}
+	return level
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	gw *gzip.Writer
+}
+
+func (grw *gzipResponseWriter) Write(data []byte) (int, error) {
+	return grw.gw.Write(data)
+}
+
+func (grw *gzipResponseWriter) WriteHeader(statusCode int) {
+	grw.ResponseWriter.Header().Del("Content-Encoding")
+	grw.ResponseWriter.Header().Add("Content-Encoding", gzipEncoding)
+	grw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (grw *gzipResponseWriter) Close() error {
+	return grw.gw.Close()
+}

--- a/internal/config/agentcfg/config.go
+++ b/internal/config/agentcfg/config.go
@@ -26,6 +26,15 @@ func Read() *Config {
 	return cfg
 }
 
+func Default() *Config {
+	cfg := &Config{
+		ServerAddr:        defaultServerAddr,
+		PollIntervalSec:   defaultPollIntervalSec,
+		ReportIntervalSec: defaultReportIntervalSec,
+	}
+	return cfg
+}
+
 func (cfg *Config) bindFlags() {
 	flag.StringVar(&cfg.ServerAddr, "a", defaultServerAddr,
 		fmt.Sprintf("server address in form of host:port (default: %s)", defaultServerAddr))

--- a/internal/config/agentcfg/config.go
+++ b/internal/config/agentcfg/config.go
@@ -3,6 +3,7 @@ package agentcfg
 import (
 	"flag"
 	"fmt"
+	"github.com/caarlos0/env/v6"
 )
 
 const (
@@ -12,23 +13,16 @@ const (
 )
 
 type Config struct {
-	ServerAddr        string
-	PollIntervalSec   int
-	ReportIntervalSec int
+	ServerAddr        string `env:"ADDRESS"`
+	PollIntervalSec   int    `env:"POLL_INTERVAL"`
+	ReportIntervalSec int    `env:"REPORT_INTERVAL"`
 }
 
-func DefaultConfig() *Config {
-	return &Config{
-		ServerAddr:        defaultServerAddr,
-		PollIntervalSec:   defaultPollIntervalSec,
-		ReportIntervalSec: defaultReportIntervalSec,
-	}
-}
-
-func ReadFromCLArgs() *Config {
+func Read() *Config {
 	cfg := &Config{}
 	cfg.bindFlags()
 	flag.Parse()
+	_ = env.Parse(cfg)
 	return cfg
 }
 

--- a/internal/config/agentcfg/config.go
+++ b/internal/config/agentcfg/config.go
@@ -10,12 +10,14 @@ const (
 	defaultServerAddr        = "http://localhost:8080"
 	defaultPollIntervalSec   = 2
 	defaultReportIntervalSec = 10
+	defaultLogLevel          = "info"
 )
 
 type Config struct {
 	ServerAddr        string `env:"ADDRESS"`
 	PollIntervalSec   int    `env:"POLL_INTERVAL"`
 	ReportIntervalSec int    `env:"REPORT_INTERVAL"`
+	LogLevel          string `env:"AGENT_LOG_LEVEL" default:"info"`
 }
 
 func Read() *Config {
@@ -31,6 +33,7 @@ func Default() *Config {
 		ServerAddr:        defaultServerAddr,
 		PollIntervalSec:   defaultPollIntervalSec,
 		ReportIntervalSec: defaultReportIntervalSec,
+		LogLevel:          defaultLogLevel,
 	}
 	return cfg
 }

--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -7,12 +7,19 @@ import (
 )
 
 const (
-	defaultAddr = ":8080"
+	defaultAddr             = ":8080"
+	defaultStoreIntervalSec = 300
+	defaultStorageFilePath  = "./metrics.json"
+	defaultRestoreOnStartup = false
 )
 
 type Config struct {
-	Addr     string `env:"ADDRESS"`
 	LogLevel string `env:"SERVER_LOG_LEVEL" default:"info"`
+
+	Addr             string `env:"ADDRESS"`
+	StoreIntervalSec int    `env:"STORE_INTERVAL"`
+	StorageFilePath  string `env:"FILE_STORAGE_PATH"`
+	RestoreOnStartup bool   `env:"RESTORE"`
 }
 
 func Read() *Config {
@@ -26,4 +33,10 @@ func Read() *Config {
 func (cfg *Config) bindFlags() {
 	flag.StringVar(&cfg.Addr, "a", defaultAddr,
 		fmt.Sprintf("server address in form of host:port (default: %s)", defaultAddr))
+	flag.IntVar(&cfg.StoreIntervalSec, "i", defaultStoreIntervalSec,
+		"metrics storing interval in seconds (0 for synchronous store)")
+	flag.StringVar(&cfg.StorageFilePath, "f", defaultStorageFilePath,
+		"metrics storage file path")
+	flag.BoolVar(&cfg.RestoreOnStartup, "r", defaultRestoreOnStartup,
+		"flag for restoring metrics on startup")
 }

--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -3,6 +3,7 @@ package servercfg
 import (
 	"flag"
 	"fmt"
+	"github.com/caarlos0/env/v6"
 )
 
 const (
@@ -10,22 +11,18 @@ const (
 )
 
 type Config struct {
-	Addr string
+	Addr string `env:"ADDRESS"`
 }
 
-func DefaultConfig() *Config {
-	return &Config{
-		Addr: defaultAddr,
-	}
-}
-
-func ReadFromCLArgs() *Config {
+func Read() *Config {
 	cfg := &Config{}
 	cfg.bindFlags()
 	flag.Parse()
+	_ = env.Parse(cfg)
 	return cfg
 }
 
 func (cfg *Config) bindFlags() {
-	flag.StringVar(&cfg.Addr, "a", defaultAddr, fmt.Sprintf("server address in form of host:port (default: %s)", defaultAddr))
+	flag.StringVar(&cfg.Addr, "a", defaultAddr,
+		fmt.Sprintf("server address in form of host:port (default: %s)", defaultAddr))
 }

--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -11,7 +11,8 @@ const (
 )
 
 type Config struct {
-	Addr string `env:"ADDRESS"`
+	Addr     string `env:"ADDRESS"`
+	LogLevel string `env:"SERVER_LOG_LEVEL" default:"info"`
 }
 
 func Read() *Config {

--- a/internal/dump/dumper.go
+++ b/internal/dump/dumper.go
@@ -1,0 +1,82 @@
+package dump
+
+import (
+	"encoding/json"
+	"github.com/andrewsvn/metrics-overseer/internal/model"
+	"github.com/andrewsvn/metrics-overseer/internal/repository"
+	"go.uber.org/zap"
+	"os"
+)
+
+type StorageDumper struct {
+	filename string
+
+	ms     repository.Storage
+	logger *zap.Logger
+}
+
+func NewStorageDumper(filename string, storage repository.Storage, logger *zap.Logger) *StorageDumper {
+	return &StorageDumper{
+		filename: filename,
+		ms:       storage,
+		logger:   logger,
+	}
+}
+
+func (sd *StorageDumper) Store() {
+	sd.logger.Info("Storing metrics to file", zap.String("filename", sd.filename))
+	metrics, err := sd.ms.GetAllSorted()
+	if err != nil {
+		sd.logger.Error("Error getting metrics to store", zap.Error(err))
+		return
+	}
+	data, err := sd.serializeMetrics(metrics)
+	if err != nil {
+		sd.logger.Error("Error serializing metrics to JSON", zap.Error(err))
+		return
+	}
+	err = os.WriteFile(sd.filename, data, 0644)
+	if err != nil {
+		sd.logger.Error("Error storing metrics to file", zap.Error(err))
+	}
+}
+
+func (sd *StorageDumper) serializeMetrics(metrics []*model.Metrics) ([]byte, error) {
+	data := []byte("[\n")
+
+	for i, metric := range metrics {
+		bytes, err := json.Marshal(metric)
+		if err != nil {
+			return nil, err
+		}
+
+		data = append(data, []byte("  ")...)
+		data = append(data, bytes...)
+		if i != len(metrics)-1 {
+			data = append(data, ',')
+		}
+		data = append(data, '\n')
+	}
+	data = append(data, ']')
+
+	return data, nil
+}
+
+func (sd *StorageDumper) Load() {
+	sd.logger.Info("Loading metrics from file", zap.String("filename", sd.filename))
+	bytes, err := os.ReadFile(sd.filename)
+	if err != nil {
+		sd.logger.Info("Unable to load metrics from file", zap.String("filename", sd.filename))
+		return
+	}
+	metrics := make([]*model.Metrics, 0)
+	err = json.Unmarshal(bytes, &metrics)
+	if err != nil {
+		sd.logger.Error("Error unmarshalling metrics", zap.Error(err))
+		return
+	}
+	err = sd.ms.SetAll(metrics)
+	if err != nil {
+		sd.logger.Error("Error storing metrics", zap.Error(err))
+	}
+}

--- a/internal/handler/error.go
+++ b/internal/handler/error.go
@@ -1,0 +1,33 @@
+package handler
+
+import "net/http"
+
+type HandlerError struct {
+	StatusCode int
+	Message    string
+}
+
+var (
+	InternalError *HandlerError = &HandlerError{
+		StatusCode: http.StatusInternalServerError,
+		Message:    http.StatusText(http.StatusInternalServerError),
+	}
+)
+
+func NewValidationHandlerError(message string) *HandlerError {
+	return &HandlerError{
+		StatusCode: http.StatusBadRequest,
+		Message:    message,
+	}
+}
+
+func NewNotFoundHandlerError(message string) *HandlerError {
+	return &HandlerError{
+		StatusCode: http.StatusNotFound,
+		Message:    message,
+	}
+}
+
+func (err *HandlerError) Render(rw http.ResponseWriter) {
+	http.Error(rw, err.Message, err.StatusCode)
+}

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -42,20 +42,20 @@ func (mh *MetricsHandlers) GetRouter() *chi.Mux {
 	lg := middleware.NewLoggable(mh.logger)
 	r.Use(lg.Middleware)
 
-	r.Post("/update/{mtype}/{id}/{value}", mh.UpdateByPathHandler())
+	r.Post("/update/{mtype}/{id}/{value}", mh.updateByPathHandler())
 	r.Route("/update", func(r chi.Router) {
-		r.Post("/", mh.UpdateByBodyHandler())
+		r.Post("/", mh.updateByBodyHandler())
 	})
 	r.Route("/value", func(r chi.Router) {
-		r.Post("/", mh.GetJSONValueHandler())
+		r.Post("/", mh.getJSONValueHandler())
 	})
-	r.Get("/value/{mtype}/{id}", mh.GetPlainValueHandler())
-	r.Get("/", mh.ShowMetricsPage())
+	r.Get("/value/{mtype}/{id}", mh.getPlainValueHandler())
+	r.Get("/", mh.showMetricsPage())
 
 	return r
 }
 
-func (mh *MetricsHandlers) ShowMetricsPage() http.HandlerFunc {
+func (mh *MetricsHandlers) showMetricsPage() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("Content-Type", "text/html")
 		rw.WriteHeader(http.StatusOK)
@@ -69,7 +69,7 @@ func (mh *MetricsHandlers) ShowMetricsPage() http.HandlerFunc {
 	}
 }
 
-func (mh *MetricsHandlers) UpdateByPathHandler() http.HandlerFunc {
+func (mh *MetricsHandlers) updateByPathHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		mtype := chi.URLParam(r, "mtype")
 		id := chi.URLParam(r, "id")
@@ -92,7 +92,7 @@ func (mh *MetricsHandlers) UpdateByPathHandler() http.HandlerFunc {
 	}
 }
 
-func (mh *MetricsHandlers) UpdateByBodyHandler() http.HandlerFunc {
+func (mh *MetricsHandlers) updateByBodyHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		defer func() {
 			err := r.Body.Close()
@@ -123,7 +123,7 @@ func (mh *MetricsHandlers) UpdateByBodyHandler() http.HandlerFunc {
 	}
 }
 
-func (mh *MetricsHandlers) GetPlainValueHandler() http.HandlerFunc {
+func (mh *MetricsHandlers) getPlainValueHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		mtype := chi.URLParam(r, "mtype")
 		id := chi.URLParam(r, "id")
@@ -138,7 +138,7 @@ func (mh *MetricsHandlers) GetPlainValueHandler() http.HandlerFunc {
 	}
 }
 
-func (mh *MetricsHandlers) GetJSONValueHandler() http.HandlerFunc {
+func (mh *MetricsHandlers) getJSONValueHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		metric := &model.Metrics{}
 		if err := json.NewDecoder(r.Body).Decode(metric); err != nil {

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -43,10 +43,12 @@ func (mh *MetricsHandlers) GetRouter() *chi.Mux {
 	r.Use(lg.Middleware)
 
 	r.Post("/update/{mtype}/{id}/{value}", mh.UpdateByPathHandler())
-	r.Post("/update", mh.UpdateByBodyHandler())
-	r.Post("/update/", mh.UpdateByBodyHandler())
-	r.Post("/value", mh.GetJSONValueHandler())
-	r.Post("/value/", mh.GetJSONValueHandler())
+	r.Route("/update", func(r chi.Router) {
+		r.Post("/", mh.UpdateByBodyHandler())
+	})
+	r.Route("/value", func(r chi.Router) {
+		r.Post("/", mh.GetJSONValueHandler())
+	})
 	r.Get("/value/{mtype}/{id}", mh.GetPlainValueHandler())
 	r.Get("/", mh.ShowMetricsPage())
 

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -44,7 +44,9 @@ func (mh *MetricsHandlers) GetRouter() *chi.Mux {
 
 	r.Post("/update/{mtype}/{id}/{value}", mh.UpdateByPathHandler())
 	r.Post("/update", mh.UpdateByBodyHandler())
+	r.Post("/update/", mh.UpdateByBodyHandler())
 	r.Post("/value", mh.GetJSONValueHandler())
+	r.Post("/value/", mh.GetJSONValueHandler())
 	r.Get("/value/{mtype}/{id}", mh.GetPlainValueHandler())
 	r.Get("/", mh.ShowMetricsPage())
 

--- a/internal/handler/middleware/compressing.go
+++ b/internal/handler/middleware/compressing.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"github.com/andrewsvn/metrics-overseer/internal/compress"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type Compressing struct {
+	compr  *compress.Compressor
+	logger *zap.Logger
+}
+
+func NewCompressing(l *zap.Logger) *Compressing {
+	return &Compressing{
+		compr:  compress.NewCompressor(l, compress.NewGzipWriteEngine()),
+		logger: l,
+	}
+}
+
+func (c *Compressing) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		crw, err := c.compr.CreateCompressWriter(w, r)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		if crw != nil {
+			defer func() {
+				err = crw.Close()
+				if err != nil {
+					c.logger.Error("Error closing compress writer", zap.Error(err))
+				}
+			}()
+			next.ServeHTTP(crw, r)
+		} else {
+			next.ServeHTTP(w, r)
+		}
+	})
+}

--- a/internal/handler/middleware/loggable.go
+++ b/internal/handler/middleware/loggable.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+	"net/http"
+	"time"
+)
+
+type Loggable struct {
+	logger *zap.Logger
+	prefix string
+}
+
+func NewLoggable(level, prefix string) (*Loggable, error) {
+	lvl, err := zap.ParseAtomicLevel(level)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing log level: %w", err)
+	}
+
+	lcfg := zap.NewProductionConfig()
+	lcfg.Level = lvl
+
+	logger, err := lcfg.Build()
+	if err != nil {
+		return nil, fmt.Errorf("error creating logger: %w", err)
+	}
+
+	return &Loggable{
+		logger: logger,
+		prefix: prefix,
+	}, nil
+}
+
+type enrichedResponseWriter struct {
+	http.ResponseWriter
+
+	Status      int
+	ContentSize int
+}
+
+func newEnrichedResponseWriter(w http.ResponseWriter) *enrichedResponseWriter {
+	return &enrichedResponseWriter{
+		ResponseWriter: w,
+	}
+}
+
+func (w *enrichedResponseWriter) WriteHeader(status int) {
+	w.Status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *enrichedResponseWriter) Write(b []byte) (int, error) {
+	w.ContentSize = len(b)
+	return w.ResponseWriter.Write(b)
+}
+
+func (l *Loggable) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func(logger *zap.Logger) {
+			_ = logger.Sync()
+		}(l.logger)
+
+		sl := l.logger.Sugar()
+		sl.Infow(fmt.Sprintf("[%s] Request received", l.prefix),
+			"url", r.URL.String(),
+			"method", r.Method)
+
+		ew := newEnrichedResponseWriter(w)
+		start := time.Now()
+		next.ServeHTTP(ew, r)
+		duration := time.Since(start)
+
+		sl.Infow(fmt.Sprintf("[%s] Request processed", l.prefix),
+			"url", r.URL.String(),
+			"method", r.Method,
+			"status", ew.Status,
+			"responseSize", ew.ContentSize,
+			"durationMs", duration.Milliseconds())
+	})
+}

--- a/internal/handler/middleware/logging.go
+++ b/internal/handler/middleware/logging.go
@@ -61,6 +61,6 @@ func (l *HTTPLogging) Middleware(next http.Handler) http.Handler {
 			"method", r.Method,
 			"status", ew.ResponseStatus,
 			"responseSize", ew.ResponseSize,
-			"durationMs", duration.Milliseconds())
+			"duration", duration.String())
 	})
 }

--- a/internal/handler/middleware/logging.go
+++ b/internal/handler/middleware/logging.go
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-type Loggable struct {
+type HTTPLogging struct {
 	logger *zap.Logger
 }
 
-func NewLoggable(logger *zap.Logger) *Loggable {
-	return &Loggable{
+func NewHTTPLogging(logger *zap.Logger) *HTTPLogging {
+	return &HTTPLogging{
 		logger: logger,
 	}
 }
@@ -40,8 +40,8 @@ func (ew *enrichedResponseWriter) Write(b []byte) (int, error) {
 	return ew.ResponseSize, err
 }
 
-func (l *Loggable) MiddlewareFunc(next http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func (l *HTTPLogging) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func(logger *zap.Logger) {
 			_ = logger.Sync()
 		}(l.logger)
@@ -62,9 +62,5 @@ func (l *Loggable) MiddlewareFunc(next http.Handler) http.HandlerFunc {
 			"status", ew.ResponseStatus,
 			"responseSize", ew.ResponseSize,
 			"durationMs", duration.Milliseconds())
-	}
-}
-
-func (l *Loggable) Middleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(l.MiddlewareFunc(next))
+	})
 }

--- a/internal/logging/zap.go
+++ b/internal/logging/zap.go
@@ -1,0 +1,23 @@
+package logging
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+)
+
+func NewZapLogger(logLevel string) (*zap.Logger, error) {
+	lvl, err := zap.ParseAtomicLevel(logLevel)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing log level: %w", err)
+	}
+
+	lcfg := zap.NewProductionConfig()
+	lcfg.Level = lvl
+
+	logger, err := lcfg.Build()
+	if err != nil {
+		return nil, fmt.Errorf("error creating l: %w", err)
+	}
+
+	return logger, nil
+}

--- a/internal/logging/zap.go
+++ b/internal/logging/zap.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"fmt"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func NewZapLogger(logLevel string) (*zap.Logger, error) {
@@ -12,6 +13,8 @@ func NewZapLogger(logLevel string) (*zap.Logger, error) {
 	}
 
 	lcfg := zap.NewProductionConfig()
+	lcfg.DisableCaller = true
+	lcfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	lcfg.Level = lvl
 
 	logger, err := lcfg.Build()

--- a/internal/logging/zap.go
+++ b/internal/logging/zap.go
@@ -19,7 +19,7 @@ func NewZapLogger(logLevel string) (*zap.Logger, error) {
 
 	logger, err := lcfg.Build()
 	if err != nil {
-		return nil, fmt.Errorf("error creating l: %w", err)
+		return nil, fmt.Errorf("error creating logger: %w", err)
 	}
 
 	return logger, nil

--- a/internal/logging/zap.go
+++ b/internal/logging/zap.go
@@ -15,6 +15,7 @@ func NewZapLogger(logLevel string) (*zap.Logger, error) {
 	lcfg := zap.NewProductionConfig()
 	lcfg.DisableCaller = true
 	lcfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	lcfg.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
 	lcfg.Level = lvl
 
 	logger, err := lcfg.Build()

--- a/internal/model/metrics.go
+++ b/internal/model/metrics.go
@@ -14,17 +14,29 @@ const (
 
 // store Delta and Value as pointers to support uninitialized state
 // separated from default value without additional flags
+
 type Metrics struct {
 	ID    string   `json:"id"`
 	MType string   `json:"type"`
 	Delta *int64   `json:"delta,omitempty"`
 	Value *float64 `json:"value,omitempty"`
-	Hash  string   `json:"hash,omitempty"`
+	Hash  string   `json:"-"`
 }
 
 var (
 	ErrIncorrectAccess = errors.New("wrong access method used for metric")
 )
+
+func NewMetrics(id string, mType string, delta *int64, value *float64) *Metrics {
+	m := &Metrics{
+		ID:    id,
+		MType: mType,
+		Delta: delta,
+		Value: value,
+	}
+	m.UpdateHash()
+	return m
+}
 
 func NewGaugeMetrics(id string) *Metrics {
 	m := &Metrics{
@@ -50,14 +62,14 @@ func (m *Metrics) Reset() {
 	m.UpdateHash()
 }
 
-func (m Metrics) GetGauge() (*float64, error) {
+func (m *Metrics) GetGauge() (*float64, error) {
 	if m.MType != Gauge {
 		return nil, ErrIncorrectAccess
 	}
 	return m.Value, nil
 }
 
-func (m Metrics) GetCounter() (*int64, error) {
+func (m *Metrics) GetCounter() (*int64, error) {
 	if m.MType != Counter {
 		return nil, ErrIncorrectAccess
 	}
@@ -103,7 +115,7 @@ func (m *Metrics) UpdateHash() {
 	m.Hash = string(md5.New().Sum(bytes))
 }
 
-func (m Metrics) StringValue() string {
+func (m *Metrics) StringValue() string {
 	const NotAvailable = "N/A"
 	switch m.MType {
 	case Counter:

--- a/internal/repository/memstorage.go
+++ b/internal/repository/memstorage.go
@@ -70,6 +70,13 @@ func (ms *MemStorage) GetAllSorted() ([]*model.Metrics, error) {
 	return mlist, nil
 }
 
+func (ms *MemStorage) SetAll(metrics []*model.Metrics) error {
+	for _, m := range metrics {
+		ms.data[m.ID] = model.NewMetrics(m.ID, m.MType, m.Delta, m.Value)
+	}
+	return nil
+}
+
 func (ms *MemStorage) ResetAll() error {
 	for _, m := range ms.data {
 		m.Reset()

--- a/internal/repository/memstorage.go
+++ b/internal/repository/memstorage.go
@@ -51,6 +51,14 @@ func (ms *MemStorage) AddCounter(id string, delta int64) error {
 	return m.AddCounter(delta)
 }
 
+func (ms *MemStorage) GetByID(id string) (*model.Metrics, error) {
+	m, exists := ms.data[id]
+	if !exists {
+		return nil, ErrMetricNotFound
+	}
+	return m, nil
+}
+
 func (ms *MemStorage) GetAllSorted() ([]*model.Metrics, error) {
 	mlist := make([]*model.Metrics, 0, len(ms.data))
 	for _, v := range ms.data {

--- a/internal/repository/memstorage_test.go
+++ b/internal/repository/memstorage_test.go
@@ -115,6 +115,6 @@ func TestMemStorageGetByID(t *testing.T) {
 	assert.Equal(t, 1.11, *metric.Value)
 	assert.Nil(t, metric.Delta)
 
-	metric, err = ms.GetByID("cnt2")
+	_, err = ms.GetByID("cnt2")
 	require.ErrorAs(t, err, &ErrMetricNotFound)
 }

--- a/internal/repository/memstorage_test.go
+++ b/internal/repository/memstorage_test.go
@@ -11,10 +11,10 @@ import (
 func TestMemStorageCounters(t *testing.T) {
 	ms := NewMemStorage()
 
-	ms.AddCounter("cnt1", 1)
-	ms.AddCounter("cnt2", 2)
-	ms.AddCounter("cnt1", 3)
-	ms.AddCounter("cnt2", 4)
+	_ = ms.AddCounter("cnt1", 1)
+	_ = ms.AddCounter("cnt2", 2)
+	_ = ms.AddCounter("cnt1", 3)
+	_ = ms.AddCounter("cnt2", 4)
 
 	cnt1, err := ms.GetCounter("cnt1")
 	assert.NoError(t, err)
@@ -25,8 +25,8 @@ func TestMemStorageCounters(t *testing.T) {
 	_, err = ms.GetCounter("cnt3")
 	assert.ErrorAs(t, err, &ErrMetricNotFound)
 
-	ms.AddCounter("cnt1", -2)
-	ms.AddCounter("cnt2", -8)
+	_ = ms.AddCounter("cnt1", -2)
+	_ = ms.AddCounter("cnt2", -8)
 	cnt1, _ = ms.GetCounter("cnt1")
 	assert.Equal(t, int64(2), *cnt1)
 	cnt2, _ = ms.GetCounter("cnt2")
@@ -44,8 +44,8 @@ func TestMemStorageCounters(t *testing.T) {
 func TestMemStorageGauges(t *testing.T) {
 	ms := NewMemStorage()
 
-	ms.SetGauge("gauge1", 1.11)
-	ms.SetGauge("gauge2", 3.33)
+	_ = ms.SetGauge("gauge1", 1.11)
+	_ = ms.SetGauge("gauge2", 3.33)
 
 	g1, err := ms.GetGauge("gauge1")
 	assert.NoError(t, err)
@@ -56,8 +56,8 @@ func TestMemStorageGauges(t *testing.T) {
 	_, err = ms.GetGauge("gauge3")
 	assert.ErrorAs(t, err, &ErrMetricNotFound)
 
-	ms.SetGauge("gauge1", 0.0)
-	ms.SetGauge("gauge2", -2.22)
+	_ = ms.SetGauge("gauge1", 0.0)
+	_ = ms.SetGauge("gauge2", -2.22)
 	g1, _ = ms.GetGauge("gauge1")
 	assert.Equal(t, 0.0, *g1)
 	g2, _ = ms.GetGauge("gauge2")
@@ -70,10 +70,10 @@ func TestMemStorageGauges(t *testing.T) {
 func TestMemStorageGetAll(t *testing.T) {
 	ms := NewMemStorage()
 
-	ms.SetGauge("1gauge1", 1.11)
-	ms.SetGauge("2gauge2", 3.33)
-	ms.AddCounter("1cnt1", 1)
-	ms.AddCounter("2cnt2", 2)
+	_ = ms.SetGauge("1gauge1", 1.11)
+	_ = ms.SetGauge("2gauge2", 3.33)
+	_ = ms.AddCounter("1cnt1", 1)
+	_ = ms.AddCounter("2cnt2", 2)
 
 	metrics, err := ms.GetAllSorted()
 	require.NoError(t, err)
@@ -81,10 +81,10 @@ func TestMemStorageGetAll(t *testing.T) {
 	assert.Equal(t, "1cnt1", metrics[0].ID)
 	assert.Equal(t, "1gauge1", metrics[1].ID)
 
-	ms.SetGauge("0gauge0", 2.22)
-	ms.SetGauge("2gauge2", -3.33)
-	ms.AddCounter("0cnt0", 3)
-	ms.AddCounter("2cnt2", -2)
+	_ = ms.SetGauge("0gauge0", 2.22)
+	_ = ms.SetGauge("2gauge2", -3.33)
+	_ = ms.AddCounter("0cnt0", 3)
+	_ = ms.AddCounter("2cnt2", -2)
 
 	metrics, err = ms.GetAllSorted()
 	require.NoError(t, err)
@@ -93,4 +93,28 @@ func TestMemStorageGetAll(t *testing.T) {
 	assert.Equal(t, "0gauge0", metrics[1].ID)
 	assert.Equal(t, "2cnt2", metrics[4].ID)
 	assert.Equal(t, "2gauge2", metrics[5].ID)
+}
+
+func TestMemStorageGetByID(t *testing.T) {
+	ms := NewMemStorage()
+
+	_ = ms.SetGauge("gauge1", 1.11)
+	_ = ms.AddCounter("cnt1", 1)
+
+	metric, err := ms.GetByID("cnt1")
+	require.NoError(t, err)
+	assert.Equal(t, "cnt1", metric.ID)
+	assert.Equal(t, model.Counter, metric.MType)
+	assert.Equal(t, int64(1), *metric.Delta)
+	assert.Nil(t, metric.Value)
+
+	metric, err = ms.GetByID("gauge1")
+	require.NoError(t, err)
+	assert.Equal(t, "gauge1", metric.ID)
+	assert.Equal(t, model.Gauge, metric.MType)
+	assert.Equal(t, 1.11, *metric.Value)
+	assert.Nil(t, metric.Delta)
+
+	metric, err = ms.GetByID("cnt2")
+	require.ErrorAs(t, err, &ErrMetricNotFound)
 }

--- a/internal/repository/storage.go
+++ b/internal/repository/storage.go
@@ -6,9 +6,10 @@ import (
 	"github.com/andrewsvn/metrics-overseer/internal/model"
 )
 
-// all methods have an option to return error in case
-// when some internal storage problem occurs or method is unsupported for chosen metric
+// all methods can return error in case when some internal storage problem occurs
+// or method is unsupported for chosen metric
 // error is not returned if data is not found in get methods
+
 type Storage interface {
 	GetGauge(id string) (*float64, error)
 	SetGauge(id string, value float64) error
@@ -16,7 +17,9 @@ type Storage interface {
 	GetCounter(id string) (*int64, error)
 	AddCounter(id string, delta int64) error
 
-	// should return full list of metric sorted by ID lexicographically
+	GetByID(id string) (*model.Metrics, error)
+
+	// GetAllSorted should return the full list of metrics sorted by ID lexicographically
 	GetAllSorted() ([]*model.Metrics, error)
 
 	ResetAll() error

--- a/internal/repository/storage.go
+++ b/internal/repository/storage.go
@@ -21,6 +21,7 @@ type Storage interface {
 
 	// GetAllSorted should return the full list of metrics sorted by ID lexicographically
 	GetAllSorted() ([]*model.Metrics, error)
+	SetAll(metrics []*model.Metrics) error
 
 	ResetAll() error
 }

--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -3,11 +3,11 @@ package service
 import (
 	_ "embed"
 	"fmt"
-	"html/template"
-	"io"
-
+	"github.com/andrewsvn/metrics-overseer/internal/dump"
 	"github.com/andrewsvn/metrics-overseer/internal/model"
 	"github.com/andrewsvn/metrics-overseer/internal/repository"
+	"html/template"
+	"io"
 )
 
 //go:embed resources/metricspage.html
@@ -15,6 +15,7 @@ var metricspage string
 
 type MetricsService struct {
 	storage        repository.Storage
+	dumper         *dump.StorageDumper
 	allMetricsTmpl *template.Template
 }
 
@@ -28,12 +29,32 @@ func NewMetricsService(st repository.Storage) *MetricsService {
 	}
 }
 
+func (ms *MetricsService) AttachDumper(dm *dump.StorageDumper) {
+	ms.dumper = dm
+}
+
 func (ms *MetricsService) AccumulateCounter(id string, inc int64) error {
-	return ms.storage.AddCounter(id, inc)
+	err := ms.storage.AddCounter(id, inc)
+	if err != nil {
+		return err
+	}
+
+	if ms.dumper != nil {
+		ms.dumper.Store()
+	}
+	return nil
 }
 
 func (ms *MetricsService) SetGauge(id string, val float64) error {
-	return ms.storage.SetGauge(id, val)
+	err := ms.storage.SetGauge(id, val)
+	if err != nil {
+		return err
+	}
+
+	if ms.dumper != nil {
+		ms.dumper.Store()
+	}
+	return nil
 }
 
 func (ms *MetricsService) GetCounter(id string) (*int64, error) {

--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -44,6 +44,17 @@ func (ms *MetricsService) GetGauge(id string) (*float64, error) {
 	return ms.storage.GetGauge(id)
 }
 
+func (ms *MetricsService) GetMetric(id, mtype string) (*model.Metrics, error) {
+	metric, err := ms.storage.GetByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if metric.MType != mtype {
+		return nil, model.ErrIncorrectAccess
+	}
+	return metric, nil
+}
+
 func (ms *MetricsService) GenerateAllMetricsHTML(w io.Writer) error {
 	if ms.allMetricsTmpl == nil {
 		tmpl := template.New("metricspage")


### PR DESCRIPTION
Server now supports loading initial metrics data on startup from json data stored in file.
Server now can store metrics data in file in 2 modes:
- by timer determined by config option (if interval > 0)
- or synchronously on metric update (if interval == 0)

New options:
- Initial metric load from file (default: false): env RESTORE=true or flag -r
- Metric file storage (default: ./metrics.json): env FILE_STORAGE_PATH or flag -f
- Metric storage interval, sec (default: 300): env STORE_INTERVAL or flag -i 