### PR TITLE
Increment 14

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,7 +40,7 @@ func run() error {
 	}()
 
 	msrv := service.NewMetricsService(stor)
-	mhandlers := handler.NewMetricsHandlers(msrv, logger)
+	mhandlers := handler.NewMetricsHandlers(msrv, &cfg.SecurityConfig, logger)
 	r := mhandlers.GetRouter()
 
 	addr := strings.Trim(cfg.Addr, "\"")

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/andrewsvn/metrics-overseer/internal/config/servercfg"
 	"github.com/andrewsvn/metrics-overseer/internal/db"
 	"github.com/andrewsvn/metrics-overseer/internal/logging"
 	"github.com/andrewsvn/metrics-overseer/internal/mocks"
@@ -493,7 +494,8 @@ func setupServerWithMemStorage() *httptest.Server {
 	msrv := service.NewMetricsService(mstor)
 	_ = msrv.AccumulateCounter(ctx, "cnt1", 10)
 	_ = msrv.SetGauge(ctx, "gauge1", 3.14)
-	mhandlers := handler.NewMetricsHandlers(msrv, logger)
+
+	mhandlers := handler.NewMetricsHandlers(msrv, &servercfg.SecurityConfig{}, logger)
 
 	return httptest.NewServer(mhandlers.GetRouter())
 }
@@ -503,7 +505,7 @@ func setupServerWithDummyDBStorage(conn db.Connection) *httptest.Server {
 
 	mstor := repository.NewPostgresDBStorage(conn, logger, &retrying.NoRetryPolicy{})
 	msrv := service.NewMetricsService(mstor)
-	mhandlers := handler.NewMetricsHandlers(msrv, logger)
+	mhandlers := handler.NewMetricsHandlers(msrv, &servercfg.SecurityConfig{}, logger)
 
 	return httptest.NewServer(mhandlers.GetRouter())
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -38,7 +38,7 @@ func NewAgent(cfg *agentcfg.Config, logger *zap.Logger) (*Agent, error) {
 	)
 
 	serverAddr := strings.Trim(cfg.ServerAddr, "\"")
-	sndr, err := sender.NewRestSender(serverAddr, logger, reportRetryPolicy)
+	sndr, err := sender.NewRestSender(serverAddr, logger, reportRetryPolicy, cfg.SecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("can't construct agent from config: %w", err)
 	}

--- a/internal/agent/sender/rest_test.go
+++ b/internal/agent/sender/rest_test.go
@@ -14,13 +14,13 @@ func TestRestSender(t *testing.T) {
 	logger, _ := logging.NewZapLogger("info")
 	retryPolicy := retrying.NewLinearPolicy(3, 1, 2)
 
-	_, err := NewRestSender("http:localhost:8080", logger, retryPolicy)
+	_, err := NewRestSender("http:localhost:8080", logger, retryPolicy, "")
 	require.Error(t, err)
 
-	_, err = NewRestSender("http://localhost:8o8o", logger, retryPolicy)
+	_, err = NewRestSender("http://localhost:8o8o", logger, retryPolicy, "")
 	require.Error(t, err)
 
-	rs, err := NewRestSender("localhost:8080", logger, retryPolicy)
+	rs, err := NewRestSender("localhost:8080", logger, retryPolicy, "")
 	require.NoError(t, err)
 
 	url := rs.composePostMetricByPathURL("cnt1", model.Counter, "10")

--- a/internal/config/agentcfg/config.go
+++ b/internal/config/agentcfg/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	ServerAddr        string `env:"ADDRESS"`
 	PollIntervalSec   int    `env:"POLL_INTERVAL"`
 	ReportIntervalSec int    `env:"REPORT_INTERVAL"`
+	SecretKey         string `env:"KEY"`
 	LogLevel          string `env:"AGENT_LOG_LEVEL" default:"info"`
 }
 
@@ -58,4 +59,6 @@ func (cfg *Config) bindFlags() {
 		fmt.Sprintf("metrics polling interval, seconds (default: %d)", defaultPollIntervalSec))
 	flag.IntVar(&cfg.ReportIntervalSec, "r", defaultReportIntervalSec,
 		fmt.Sprintf("metrics reporting interval, seconds (default: %d)", defaultReportIntervalSec))
+	flag.StringVar(&cfg.SecretKey, "k", "",
+		"secret key for request signing")
 }

--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -36,10 +36,15 @@ type PostgresRetryConfig struct {
 	RetryDelayIncrementSec int `env:"PG_RETRY_DELAY_INCREMENT" envDefault:"2"`
 }
 
+type SecurityConfig struct {
+	SecretKey string `env:"KEY"`
+}
+
 type Config struct {
 	FileStorageConfig
 	DatabaseConfig
 	PostgresRetryConfig
+	SecurityConfig
 
 	LogLevel string `env:"SERVER_LOG_LEVEL" default:"info"`
 	Addr     string `env:"ADDRESS"`
@@ -66,4 +71,7 @@ func (cfg *Config) bindFlags() {
 
 	flag.StringVar(&cfg.DBConnString, "d", "",
 		"postgres database connection string (should be specified to enable postgres storage)")
+
+	flag.StringVar(&cfg.SecretKey, "k", "",
+		"secret key for verifying requests and signing responses")
 }

--- a/internal/encrypt/hashsign.go
+++ b/internal/encrypt/hashsign.go
@@ -1,0 +1,56 @@
+package encrypt
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+const (
+	SignHeader = "HashSHA256"
+)
+
+var (
+	ErrSignatureInvalid = errors.New("request signature invalid")
+)
+
+func AddSignature(key []byte, payload []byte, header http.Header) {
+	if len(key) == 0 {
+		return
+	}
+
+	sign := calculateHash(key, payload)
+	header.Add(SignHeader, base64.StdEncoding.EncodeToString(sign))
+}
+
+func GetSignature(header http.Header) ([]byte, error) {
+	signstr := header.Get(SignHeader)
+	if len(signstr) == 0 {
+		return nil, nil
+	}
+
+	sign, err := base64.StdEncoding.DecodeString(signstr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode signature from header: %w", err)
+	}
+	return sign, nil
+}
+
+func CheckSignature(key []byte, payload []byte, sign []byte) error {
+	calculated := calculateHash(key, payload)
+	if !bytes.Equal(calculated, sign) {
+		return ErrSignatureInvalid
+	}
+	return nil
+}
+
+func calculateHash(key []byte, payload []byte) []byte {
+	hfunc := sha256.New()
+	if payload != nil {
+		hfunc.Write(payload)
+	}
+	return hfunc.Sum(key)
+}

--- a/internal/handler/errorhandling/error.go
+++ b/internal/handler/errorhandling/error.go
@@ -1,35 +1,35 @@
-package handler
+package errorhandling
 
 import "net/http"
 
-type HandlingError struct {
+type Error struct {
 	StatusCode int
 	Message    string
 	Error      error
 }
 
-func NewValidationHandlerError(message string) *HandlingError {
-	return &HandlingError{
+func NewValidationHandlerError(message string) *Error {
+	return &Error{
 		StatusCode: http.StatusBadRequest,
 		Message:    message,
 	}
 }
 
-func NewNotFoundHandlerError(message string) *HandlingError {
-	return &HandlingError{
+func NewNotFoundHandlerError(message string) *Error {
+	return &Error{
 		StatusCode: http.StatusNotFound,
 		Message:    message,
 	}
 }
 
-func NewInternalServerError(err error) *HandlingError {
-	return &HandlingError{
+func NewInternalServerError(err error) *Error {
+	return &Error{
 		StatusCode: http.StatusInternalServerError,
 		Message:    http.StatusText(http.StatusInternalServerError),
 		Error:      err,
 	}
 }
 
-func (err *HandlingError) Render(rw http.ResponseWriter) {
+func (err *Error) Render(rw http.ResponseWriter) {
 	http.Error(rw, err.Message, err.StatusCode)
 }

--- a/internal/handler/middleware/authorization.go
+++ b/internal/handler/middleware/authorization.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"github.com/andrewsvn/metrics-overseer/internal/encrypt"
+	"github.com/andrewsvn/metrics-overseer/internal/handler/errorhandling"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+)
+
+type Authorization struct {
+	secretKey []byte
+	logger    *zap.SugaredLogger
+}
+
+func NewAuthorization(l *zap.Logger, secretKey string) *Authorization {
+	authLogger := l.Sugar().With("component", "authorization-middleware")
+	return &Authorization{
+		secretKey: []byte(secretKey),
+		logger:    authLogger,
+	}
+}
+
+func (auth *Authorization) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if auth.secretKey == nil {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		var err error
+
+		// backward compatibility: don't verify signature if it's not present in the request even if key is specified
+		reqSign, err := encrypt.GetSignature(r.Header)
+		if err != nil {
+			auth.logger.Warnw("Error getting signature", "error", err)
+			errorhandling.NewValidationHandlerError("can't read signature from incoming request").Render(rw)
+			return
+		}
+		if reqSign == nil {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		var payload []byte
+		if r.Body != nil {
+			payload, err = io.ReadAll(r.Body)
+			if err != nil {
+				auth.logger.Warnw("can't read incoming request body for verification", "error", err)
+				errorhandling.NewValidationHandlerError("can't read incoming request body").Render(rw)
+				return
+			}
+		}
+
+		err = encrypt.CheckSignature(auth.secretKey, payload, reqSign)
+		if err != nil {
+			if errors.Is(err, encrypt.ErrSignatureInvalid) {
+				auth.logger.Debugw("incoming request signature is invalid")
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			auth.logger.Warnw("can't verify signature", "error", err)
+			errorhandling.NewInternalServerError(err).Render(rw)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewBuffer(payload))
+		next.ServeHTTP(rw, r)
+	})
+}


### PR DESCRIPTION

SHA256-based signature supported on both agent and server sides:
Each request and response can be now signed with SHA256 hash based on secret key (common for agent and server) and body (unencoded)

Agent features:
- secret key can be specified using 'k' flag or ENV variable 'KEY'
- if the secret key is specified, each request to the server will contain 'HashSHA256' header with sign value (base64 encoded)

Server features:
- secret key can be specified using 'k' flag or ENV variable 'KEY'
- if the secret key is specified, each incoming request is checked for 'HashSHA256' header. If such header is present, it is decoded and checked to match sign based on secret key and request body
- if the secret key is specified, each response will contain 'HashSHA256' header with sign value (base64 encoded)