### PR TITLE
Increment 24

### DIFF
--- a/cmd/tools/keygen/README.md
+++ b/cmd/tools/keygen/README.md
@@ -1,0 +1,28 @@
+# cmd/tools/keygen
+
+__keygen__ tool is a simple RSA key pair generator which creates RSA keys in files 
+to support data encryption/decryption between metrics-overseer server and agent.
+
+## File format
+keygen generates both private and public keys in a separate PEM files with content 
+in PKCS1 format. Files can be then processed using pem package.
+
+## Usage
+keygen tool creates two files under one given base directory, but each file can have its
+own relative subpath - so they might be stored in different directories as a result.
+
+__Basic usage__:
+
+``` shell
+keygen <base_directory> -pr=<path_to_private_key_file> -pb=<path_to_public_key_file> 
+-bits=<rsa_key_bits>
+```
+
+Each parameter can be omitted with the following default values:
+- base_directory = "."
+- path_to_private_key_file = "private.pem"
+- path_to_public_key_file = "public.pem"
+- rsa_key_bits = 2048
+
+__Note__ that RSA standard doesn't allow to use keys lesser than 1024 bits 
+(2048 and above recommended).

--- a/cmd/tools/keygen/keygen_test.go
+++ b/cmd/tools/keygen/keygen_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRSAKeyPairGeneration(t *testing.T) {
+	const (
+		baseDir  = "key_testdata"
+		privName = "priv.pem"
+		pubName  = "pub.pem"
+	)
+
+	err := os.MkdirAll(baseDir, 0755)
+	require.NoError(t, err)
+
+	// RSA key size can't be less than 1024 bits
+	err = generateKeyPair(baseDir, privName, pubName, 512)
+	assert.Error(t, err)
+
+	err = generateKeyPair(baseDir, privName, pubName, 1024)
+	assert.NoError(t, err)
+
+	checkKeyFile(t, filepath.Join(baseDir, privName), "RSA PRIVATE KEY")
+	checkKeyFile(t, filepath.Join(baseDir, pubName), "PUBLIC KEY")
+
+	_ = os.RemoveAll(baseDir)
+}
+
+func checkKeyFile(t *testing.T, filePath string, keyType string) {
+	f, err := os.OpenFile(filePath, os.O_RDONLY, 0644)
+	require.NoError(t, err)
+	defer func(f *os.File) {
+		err := f.Close()
+		assert.NoError(t, err)
+	}(f)
+
+	scanner := bufio.NewScanner(f)
+	beginKey := "BEGIN " + keyType
+	endKey := "END " + keyType
+	hasBeginKey := false
+	hasEndKey := false
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), beginKey) {
+			hasBeginKey = true
+			continue
+		}
+		if strings.Contains(scanner.Text(), endKey) {
+			hasEndKey = true
+		}
+	}
+	assert.True(t, hasBeginKey)
+	assert.True(t, hasEndKey)
+}

--- a/cmd/tools/keygen/main.go
+++ b/cmd/tools/keygen/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func generateKeyPair(baseDir string, privateKeyName string, publicKeyName string, nBits int) error {
+	privateKey, err := rsa.GenerateKey(rand.Reader, nBits)
+	if err != nil {
+		return fmt.Errorf("error generating RSA key pair: %w", err)
+	}
+
+	var privateKeyPem bytes.Buffer
+	err = pem.Encode(&privateKeyPem, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	if err != nil {
+		return fmt.Errorf("error encoding RSA private key: %w", err)
+	}
+
+	var publicKeyPem bytes.Buffer
+	err = pem.Encode(&publicKeyPem, &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: x509.MarshalPKCS1PublicKey(&privateKey.PublicKey),
+	})
+	if err != nil {
+		return fmt.Errorf("error encoding RSA public key: %w", err)
+	}
+
+	err = os.WriteFile(filepath.Join(baseDir, privateKeyName), privateKeyPem.Bytes(), 0644)
+	if err != nil {
+		return fmt.Errorf("error writing RSA private key: %w", err)
+	}
+
+	err = os.WriteFile(filepath.Join(baseDir, publicKeyName), publicKeyPem.Bytes(), 0644)
+	if err != nil {
+		return fmt.Errorf("error writing RSA public key: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	var baseDir string
+	var privKeyName string
+	var pubKeyName string
+	var bits int
+
+	flag.StringVar(&privKeyName, "pr", "private.pem", "File name for private key")
+	flag.StringVar(&pubKeyName, "pb", "public.pem", "File name for public key")
+	flag.IntVar(&bits, "bits", 2048, "Key pair bit size (minimum 1024, not less than 2048 recommended)")
+	flag.Parse()
+
+	baseDir = flag.Arg(0)
+	if baseDir == "" {
+		baseDir = "."
+	}
+
+	err := generateKeyPair(baseDir, privKeyName, pubKeyName, bits)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("keys successfully generated in %s\n", baseDir)
+}

--- a/cmd/tools/spammer/main.go
+++ b/cmd/tools/spammer/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Fatalf("error initializing logger: %v", err)
 	}
 
-	sender, err := sending.NewRestSender(cfg.URL, &retrying.NoRetryPolicy{}, "", l)
+	sender, err := sending.NewRestSender(cfg.URL, &retrying.NoRetryPolicy{}, "", "", l)
 	if err != nil {
 		log.Fatalf("error initializing sender: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/swag v1.16.6
 	go.uber.org/zap v1.27.0
+	golang.org/x/tools v0.38.0
 )
 
 require (
@@ -56,6 +57,5 @@ require (
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
-	golang.org/x/tools v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/agent/reporter.go
+++ b/internal/agent/reporter.go
@@ -3,6 +3,10 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/andrewsvn/metrics-overseer/internal/agent/accumulation"
 	"github.com/andrewsvn/metrics-overseer/internal/agent/reporting"
 	"github.com/andrewsvn/metrics-overseer/internal/agent/sending"
@@ -10,9 +14,6 @@ import (
 	"github.com/andrewsvn/metrics-overseer/internal/model"
 	"github.com/andrewsvn/metrics-overseer/internal/retrying"
 	"go.uber.org/zap"
-	"strings"
-	"sync"
-	"time"
 )
 
 type Reporter struct {
@@ -33,7 +34,7 @@ func NewReporter(cfg *agentcfg.Config, storage *accumulation.Storage, l *zap.Log
 	)
 
 	serverAddr := strings.Trim(cfg.ServerAddr, "\"")
-	sndr, err := sending.NewRestSender(serverAddr, reportRetryPolicy, cfg.SecretKey, l)
+	sndr, err := sending.NewRestSender(serverAddr, reportRetryPolicy, cfg.SecretKey, cfg.PublicKeyPath, l)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sender: %w", err)
 	}

--- a/internal/agent/sending/rest_test.go
+++ b/internal/agent/sending/rest_test.go
@@ -1,9 +1,10 @@
 package sending
 
 import (
+	"testing"
+
 	"github.com/andrewsvn/metrics-overseer/internal/logging"
 	"github.com/andrewsvn/metrics-overseer/internal/retrying"
-	"testing"
 
 	"github.com/andrewsvn/metrics-overseer/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -14,13 +15,13 @@ func TestRestSender(t *testing.T) {
 	logger, _ := logging.NewZapLogger("info")
 	retryPolicy := retrying.NewLinearPolicy(3, 1, 2)
 
-	_, err := NewRestSender("http:localhost:8080", retryPolicy, "", logger)
+	_, err := NewRestSender("http:localhost:8080", retryPolicy, "", "", logger)
 	require.Error(t, err)
 
-	_, err = NewRestSender("http://localhost:8o8o", retryPolicy, "", logger)
+	_, err = NewRestSender("http://localhost:8o8o", retryPolicy, "", "", logger)
 	require.Error(t, err)
 
-	rs, err := NewRestSender("localhost:8080", retryPolicy, "", logger)
+	rs, err := NewRestSender("localhost:8080", retryPolicy, "", "", logger)
 	require.NoError(t, err)
 
 	url := rs.composePostMetricByPathURL("cnt1", model.Counter, "10")

--- a/internal/config/agentcfg/config.go
+++ b/internal/config/agentcfg/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	ReportIntervalSec int    `env:"REPORT_INTERVAL"`
 	GracePeriodSec    int    `env:"AGENT_GRACE_PERIOD"`
 	SecretKey         string `env:"KEY"`
+	PublicKeyPath     string `env:"CRYPTO_KEY"`
 	LogLevel          string `env:"AGENT_LOG_LEVEL" default:"info"`
 }
 
@@ -86,4 +87,6 @@ func (cfg *Config) bindFlags() {
 
 	flag.StringVar(&cfg.SecretKey, "k", "",
 		"secret key for request signing")
+	flag.StringVar(&cfg.PublicKeyPath, "crypto-key", "",
+		"path to PEM file with RSA public key for encrypting requests (no encryption if empty)")
 }

--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -53,7 +53,8 @@ type PostgresRetryConfig struct {
 // SecurityConfig contains settings related to HTTP authentication for clients of metrics-overseer server
 // including metrics-overseer agent
 type SecurityConfig struct {
-	SecretKey string `env:"KEY"`
+	SecretKey      string `env:"KEY"`
+	PrivateKeyPath string `env:"CRYPTO_KEY"`
 }
 
 // AuditConfig contains settings related to audit of metrics updates - it can be forwarded to a file and/or
@@ -109,6 +110,8 @@ func (cfg *Config) bindFlags() {
 
 	flag.StringVar(&cfg.SecretKey, "k", "",
 		"secret key for verifying requests and signing responses")
+	flag.StringVar(&cfg.PrivateKeyPath, "crypto-key", "",
+		"path to PEM file with RSA private key for decrypting requests (no decryption if empty)")
 
 	flag.StringVar(&cfg.AuditFilePath, "audit-file", "",
 		"audit file path (should be specified to enable file audit)")

--- a/internal/encrypt/aes.go
+++ b/internal/encrypt/aes.go
@@ -1,0 +1,72 @@
+package encrypt
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+)
+
+const (
+	aesKeySize = 32
+)
+
+type aesEncrypted struct {
+	Key        []byte
+	Nonce      []byte
+	Ciphertext []byte
+}
+
+func generateRandomBytes(size int) ([]byte, error) {
+	b := make([]byte, size)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func aesEncrypt(data []byte) (*aesEncrypted, error) {
+	enc := &aesEncrypted{}
+	var err error
+
+	enc.Key, err = generateRandomBytes(aesKeySize)
+	if err != nil {
+		return nil, err
+	}
+
+	aesBlock, err := aes.NewCipher(enc.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesGCM, err := cipher.NewGCM(aesBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	enc.Nonce, err = generateRandomBytes(aesGCM.NonceSize())
+	if err != nil {
+		return nil, err
+	}
+
+	enc.Ciphertext = aesGCM.Seal(nil, enc.Nonce, data, nil)
+	return enc, nil
+}
+
+func aesDecrypt(enc *aesEncrypted) ([]byte, error) {
+	aesBlock, err := aes.NewCipher(enc.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesGCM, err := cipher.NewGCM(aesBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := aesGCM.Open(nil, enc.Nonce, enc.Ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/encrypt/aes_test.go
+++ b/internal/encrypt/aes_test.go
@@ -1,0 +1,19 @@
+package encrypt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAESEncryption(t *testing.T) {
+	srctext, err := generateRandomBytes(2000)
+	require.NoError(t, err)
+
+	encrypted, err := aesEncrypt(srctext)
+	require.NoError(t, err)
+
+	decrypted, err := aesDecrypt(encrypted)
+	require.NoError(t, err)
+	require.Equal(t, srctext, decrypted)
+}

--- a/internal/encrypt/engine.go
+++ b/internal/encrypt/engine.go
@@ -1,0 +1,18 @@
+package encrypt
+
+import "errors"
+
+type Encrypter interface {
+	Encrypt([]byte) ([]byte, error)
+	EncryptingEnabled() bool
+}
+
+type Decrypter interface {
+	Decrypt([]byte) ([]byte, error)
+	DecryptingEnabled() bool
+}
+
+var (
+	ErrEncryptingDisabled = errors.New("encrypting disabled")
+	ErrDecryptingDisabled = errors.New("decrypting disabled")
+)

--- a/internal/encrypt/rsa.go
+++ b/internal/encrypt/rsa.go
@@ -1,0 +1,195 @@
+package encrypt
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+const (
+	publicKeyBlockType  = "PUBLIC KEY"
+	privateKeyBlockType = "RSA PRIVATE KEY"
+)
+
+// RSAAESEngine allows encryption/decryption of byte data using combination of RSA+AES algorithms.
+// For actual payload encryption AES algorithm is used, AES key is encrypted with RSA public key and decrypted with a
+// corresponding private key.
+// Engine implements both Encrypter and Decrypter interfaces, but each of them uses only one key, so if only
+// Encrypter is needed then RSAAESEngine can be built only with a public key provided, similar story for Decrypter
+// RSAAESEngine instances must be constructed using RSAEngineBuilder
+type RSAAESEngine struct {
+	publicKey  *rsa.PublicKey
+	privateKey *rsa.PrivateKey
+	label      []byte
+}
+
+// rsaAESEncryptedBlock is a serializable structure to transfer RSA+AES encrypted data via HTTP request body.
+// - Key contains AES algorithm key encrypted with RSA public key and BASE64 encoded.
+// - Cipher contains original []byte payload encrypted with the AES key and BASE64 encoded.
+// - Nonce contains random nonce string used for AES encryption, BASE64 encoded.
+type rsaAESEncryptedBlock struct {
+	Key    string `json:"key"`
+	Cipher string `json:"cipher"`
+	Nonce  string `json:"nonce"`
+}
+
+func (engine *RSAAESEngine) Encrypt(data []byte) ([]byte, error) {
+	if engine.publicKey == nil {
+		return nil, ErrEncryptingDisabled
+	}
+
+	aesEncData, err := aesEncrypt(data)
+	if err != nil {
+		return nil, fmt.Errorf("AES encrypting error: %w", err)
+	}
+
+	rsaEncKey, err := rsa.EncryptOAEP(
+		sha256.New(), rand.Reader, engine.publicKey, aesEncData.Key, engine.label)
+	if err != nil {
+		return nil, fmt.Errorf("RSA encrypting error: %w", err)
+	}
+
+	rsaAESEncData := &rsaAESEncryptedBlock{
+		Key:    base64.StdEncoding.EncodeToString(rsaEncKey),
+		Cipher: base64.StdEncoding.EncodeToString(aesEncData.Ciphertext),
+		Nonce:  base64.StdEncoding.EncodeToString(aesEncData.Nonce),
+	}
+
+	encryptedBytes, err := json.Marshal(rsaAESEncData)
+	if err != nil {
+		return nil, fmt.Errorf("JSON marshalling error: %w", err)
+	}
+	return encryptedBytes, nil
+}
+
+func (engine *RSAAESEngine) EncryptingEnabled() bool {
+	return engine.publicKey != nil
+}
+
+func (engine *RSAAESEngine) Decrypt(encrypted []byte) ([]byte, error) {
+	if engine.privateKey == nil {
+		return nil, ErrDecryptingDisabled
+	}
+
+	rsaAESEncData := &rsaAESEncryptedBlock{}
+	err := json.Unmarshal(encrypted, rsaAESEncData)
+	if err != nil {
+		return nil, fmt.Errorf("JSON unmarshalling error: %w", err)
+	}
+
+	rsaEncKey, err := base64.StdEncoding.DecodeString(rsaAESEncData.Key)
+	if err != nil {
+		return nil, fmt.Errorf("BASE64 decoding error: %w", err)
+	}
+
+	aesEncData := &aesEncrypted{}
+	aesEncData.Key, err = rsa.DecryptOAEP(sha256.New(), nil, engine.privateKey, rsaEncKey, engine.label)
+	if err != nil {
+		return nil, fmt.Errorf("RSA decrypt error: %w", err)
+	}
+
+	aesEncData.Ciphertext, err = base64.StdEncoding.DecodeString(rsaAESEncData.Cipher)
+	if err != nil {
+		return nil, fmt.Errorf("BASE64 decoding error: %w", err)
+	}
+
+	aesEncData.Nonce, err = base64.StdEncoding.DecodeString(rsaAESEncData.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("BASE64 decoding error: %w", err)
+	}
+
+	data, err := aesDecrypt(aesEncData)
+	if err != nil {
+		return nil, fmt.Errorf("AES decrypt error: %w", err)
+	}
+	return data, nil
+}
+
+func (engine *RSAAESEngine) DecryptingEnabled() bool {
+	return engine.privateKey != nil
+}
+
+// RSAEngineBuilder is a builder structure for RSAAESEngine which can provide any combination of private and public keys
+// depending on functional needed from the engine
+type RSAEngineBuilder struct {
+	publicKey  *rsa.PublicKey
+	privateKey *rsa.PrivateKey
+	label      []byte
+}
+
+func NewRSAEngineBuilder() *RSAEngineBuilder {
+	return &RSAEngineBuilder{}
+}
+
+func (b *RSAEngineBuilder) PublicKey(pub *rsa.PublicKey) *RSAEngineBuilder {
+	b.publicKey = pub
+	return b
+}
+
+func (b *RSAEngineBuilder) PrivateKey(priv *rsa.PrivateKey) *RSAEngineBuilder {
+	b.privateKey = priv
+	return b
+}
+
+func (b *RSAEngineBuilder) Label(label []byte) *RSAEngineBuilder {
+	b.label = label
+	return b
+}
+
+func (b *RSAEngineBuilder) Build() *RSAAESEngine {
+	label := b.label
+	if label == nil {
+		label = []byte("")
+	}
+	return &RSAAESEngine{
+		publicKey:  b.publicKey,
+		privateKey: b.privateKey,
+		label:      label,
+	}
+}
+
+// ReadRSAPublicKeyFromFile is utility function to read an RSA public key from file
+func ReadRSAPublicKeyFromFile(filePath string) (*rsa.PublicKey, error) {
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading key file %s: %w", filePath, err)
+	}
+
+	block, _ := pem.Decode(bytes)
+	if block == nil || block.Type != publicKeyBlockType {
+		return nil, fmt.Errorf("error reading key file %s: invalid PEM block or key type", filePath)
+	}
+
+	pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing public key: %w", err)
+	}
+
+	return pub, nil
+}
+
+// ReadRSAPrivateKeyFromFile is utility function to read an RSA private key from file
+func ReadRSAPrivateKeyFromFile(filePath string) (*rsa.PrivateKey, error) {
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading key file %s: %w", filePath, err)
+	}
+
+	block, _ := pem.Decode(bytes)
+	if block == nil || block.Type != privateKeyBlockType {
+		return nil, fmt.Errorf("error reading key file %s: invalid PEM block or key type", filePath)
+	}
+
+	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing public key: %w", err)
+	}
+
+	return priv, nil
+}

--- a/internal/encrypt/rsa_test.go
+++ b/internal/encrypt/rsa_test.go
@@ -1,0 +1,80 @@
+package encrypt
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRSAEngineUnlabeled(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	encrypter := NewRSAEngineBuilder().PublicKey(&priv.PublicKey).Build()
+	decrypter := NewRSAEngineBuilder().PrivateKey(priv).Build()
+
+	// sunny day scenario
+	data := []byte("a quick brown fox jumps over the lazy dog")
+	encrypted, err := encrypter.Encrypt(data)
+	assert.NoError(t, err)
+	decrypted, err := decrypter.Decrypt(encrypted)
+	assert.NoError(t, err)
+	assert.Equal(t, data, decrypted)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// decryption/encryption enabled
+	assert.True(t, encrypter.EncryptingEnabled())
+	assert.False(t, encrypter.DecryptingEnabled())
+	assert.False(t, decrypter.EncryptingEnabled())
+	assert.True(t, decrypter.DecryptingEnabled())
+	encrypted, err = decrypter.Encrypt(data)
+	assert.ErrorAs(t, err, &ErrEncryptingDisabled)
+	_, err = encrypter.Decrypt(encrypted)
+	assert.ErrorAs(t, err, &ErrDecryptingDisabled)
+
+	// big data chunk
+	data = make([]byte, 4000)
+	_, _ = rand.Read(data)
+	encrypted, err = encrypter.Encrypt(data)
+	assert.NoError(t, err)
+	decrypted, err = decrypter.Decrypt(encrypted)
+	assert.NoError(t, err)
+	assert.Equal(t, data, decrypted)
+
+	// rainy day scenario - different keys
+	encrypter = NewRSAEngineBuilder().PublicKey(&priv.PublicKey).Build()
+
+	encrypted, err = encrypter.Encrypt(data)
+	assert.NoError(t, err)
+	_, err = decrypter.Decrypt(encrypted)
+	assert.Error(t, err)
+}
+
+func TestRSAEngineLabeled(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	label := []byte("mylabel")
+
+	// sunny day scenario
+	encrypter := NewRSAEngineBuilder().PublicKey(&priv.PublicKey).Label(label).Build()
+	decrypter := NewRSAEngineBuilder().PrivateKey(priv).Label(label).Build()
+	data := []byte("a quick brown fox jumps over the lazy dog")
+	encrypted, err := encrypter.Encrypt(data)
+	assert.NoError(t, err)
+	decrypted, err := decrypter.Decrypt(encrypted)
+	assert.NoError(t, err)
+	assert.Equal(t, data, decrypted)
+
+	// rainy day scenario - different labels
+	decrypter = NewRSAEngineBuilder().PrivateKey(priv).Build()
+	encrypted, err = encrypter.Encrypt(data)
+	assert.NoError(t, err)
+	_, err = decrypter.Decrypt(encrypted)
+	assert.Error(t, err)
+}

--- a/internal/handler/middleware/decryption.go
+++ b/internal/handler/middleware/decryption.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/andrewsvn/metrics-overseer/internal/encrypt"
+	"github.com/andrewsvn/metrics-overseer/internal/handler/errorhandling"
+	"go.uber.org/zap"
+)
+
+type Decryption struct {
+	decrypter encrypt.Decrypter
+	logger    *zap.SugaredLogger
+}
+
+func NewDecryption(l *zap.Logger, dec encrypt.Decrypter) *Decryption {
+	return &Decryption{
+		decrypter: dec,
+		logger:    l.Sugar().With("component", "decryption-middleware"),
+	}
+}
+
+func (dec *Decryption) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if !dec.decrypter.DecryptingEnabled() {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		if r.Body == nil {
+			next.ServeHTTP(rw, r)
+			return
+		}
+
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			dec.logger.Warnw("can't read incoming request body", "error", err)
+			errorhandling.NewValidationHandlerError("can't read incoming request body").Render(rw)
+			return
+		}
+
+		decrypted, err := dec.decrypter.Decrypt(payload)
+		if err != nil {
+			dec.logger.Warnw("can't decrypt incoming request body", "error", err)
+			errorhandling.NewValidationHandlerError("can't decrypt incoming request body").Render(rw)
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(decrypted))
+		next.ServeHTTP(rw, r)
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,9 +59,12 @@ func Run() error {
 		msrv.SubscribeAuditor(audit.NewHTTPWriter(cfg.AuditURL))
 	}
 
-	mhandlers := handler.NewMetricsHandlers(msrv, &cfg.SecurityConfig, logger)
-	r := mhandlers.GetRouter()
+	mhandlers, err := handler.NewMetricsHandlers(msrv, &cfg.SecurityConfig, logger)
+	if err != nil {
+		return fmt.Errorf("can't initialize metrics handlers: %w", err)
+	}
 
+	r := mhandlers.GetRouter()
 	addr := strings.Trim(cfg.Addr, "\"")
 	server := &http.Server{
 		Addr:    addr,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -502,7 +502,7 @@ func setupServerWithMemStorage() *httptest.Server {
 	gm.SetGauge(3.14)
 	_ = msrv.AccumulateMetric(ctx, gm, "")
 
-	mhandlers := handler.NewMetricsHandlers(msrv, &servercfg.SecurityConfig{}, logger)
+	mhandlers, _ := handler.NewMetricsHandlers(msrv, &servercfg.SecurityConfig{}, logger)
 
 	return httptest.NewServer(mhandlers.GetRouter())
 }
@@ -512,7 +512,7 @@ func setupServerWithDummyDBStorage(conn db.Connection) *httptest.Server {
 
 	mstor := repository.NewPostgresDBStorage(conn, logger, &retrying.NoRetryPolicy{})
 	msrv := service.NewMetricsService(mstor, logger)
-	mhandlers := handler.NewMetricsHandlers(msrv, &servercfg.SecurityConfig{}, logger)
+	mhandlers, _ := handler.NewMetricsHandlers(msrv, &servercfg.SecurityConfig{}, logger)
 
 	return httptest.NewServer(mhandlers.GetRouter())
 }

--- a/makefile
+++ b/makefile
@@ -30,3 +30,13 @@ BUILD_ALL:
 	make BUILD_RESET
 	make BUILD_TEST_TOOLS
 
+POSTGRES_UP:
+	docker run --name metrics-postgres \
+      -e POSTGRES_USER=postgres \
+      -e POSTGRES_PASSWORD=p0stgres \
+      -e POSTGRES_DB=metrics-overseer \
+      -p 5432:5432 \
+      -d postgres:17
+
+POSTGRES_DOWN:
+	docker stop metrics-postgres


### PR DESCRIPTION
Added RSA+AES request body enryption support on server and agent side.

Encryption is enabled if server and agent are started with specified paths to matching private key and public key PEM files (ENV variable "CRYPTO_KEY", flag -crypto-key).

For each request a new random AES key (256bit) and AES GCM nonce (96bit) are generated.
Original body is encoded in the following way:

{
"Key": BASE64Enc(<AES256_key_encrypted_with_RSA_public_key>),
"Ciphertext": BASE64Enc(<AES256_encrypted_original_bytes>),
"Nonce": BASE64Enc(<AES256_GCM_nonce>)
}

Currently, only metrics update requests can be encrypted - both single and bulk ones.