### PR TITLE
Increment 27

### DIFF
--- a/internal/config/servercfg/config.go
+++ b/internal/config/servercfg/config.go
@@ -64,6 +64,7 @@ type PostgresRetryConfig struct {
 type SecurityConfig struct {
 	SecretKey      string `env:"KEY" json:"key"`
 	PrivateKeyPath string `env:"CRYPTO_KEY" json:"crypto_key"`
+	TrustedSubnet  string `env:"TRUSTED_SUBNET" json:"trusted_subnet"`
 }
 
 // AuditConfig contains settings related to audit of metrics updates - it can be forwarded to a file and/or
@@ -144,6 +145,8 @@ func (cfg *Config) bindFlags() {
 		"secret key for verifying requests and signing responses")
 	flag.StringVar(&cfg.PrivateKeyPath, "crypto-key", "",
 		"path to PEM file with RSA private key for decrypting requests (no decryption if empty)")
+	flag.StringVarP(&cfg.TrustedSubnet, "", "t", "",
+		"classified IP subnet address of trusted clients (checked via X-Real-IP header)")
 
 	flag.StringVar(&cfg.AuditFilePath, "audit-file", "",
 		"audit file path (should be specified to enable file audit)")

--- a/internal/handler/middleware/authorization.go
+++ b/internal/handler/middleware/authorization.go
@@ -99,14 +99,14 @@ func (auth *Authorization) verifyClientIP(rw http.ResponseWriter, r *http.Reques
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		auth.logger.Debugw("X-Real-IP header of an incoming request is invalid")
-		rw.WriteHeader(http.StatusUnauthorized)
+		rw.WriteHeader(http.StatusForbidden)
 		return false
 	}
 
 	subnet := ip.Mask(auth.trustedSubnet.Mask)
 	if !subnet.Equal(auth.trustedSubnet.IP) {
 		auth.logger.Debugw("X-Real-IP header of an incoming request is untrusted")
-		rw.WriteHeader(http.StatusUnauthorized)
+		rw.WriteHeader(http.StatusForbidden)
 		return false
 	}
 

--- a/internal/handler/middleware/authorization.go
+++ b/internal/handler/middleware/authorization.go
@@ -3,70 +3,112 @@ package middleware
 import (
 	"bytes"
 	"errors"
+	"io"
+	"net"
+	"net/http"
+
 	"github.com/andrewsvn/metrics-overseer/internal/encrypt"
 	"github.com/andrewsvn/metrics-overseer/internal/handler/errorhandling"
 	"go.uber.org/zap"
-	"io"
-	"net/http"
 )
 
 type Authorization struct {
-	secretKey []byte
-	logger    *zap.SugaredLogger
+	secretKey     []byte
+	trustedSubnet *net.IPNet
+	logger        *zap.SugaredLogger
 }
 
-func NewAuthorization(l *zap.Logger, secretKey string) *Authorization {
+func NewAuthorization(l *zap.Logger, secretKey string, trustedSubnet *net.IPNet) *Authorization {
 	authLogger := l.Sugar().With("component", "authorization-middleware")
 	return &Authorization{
-		secretKey: []byte(secretKey),
-		logger:    authLogger,
+		secretKey:     []byte(secretKey),
+		trustedSubnet: trustedSubnet,
+		logger:        authLogger,
 	}
 }
 
 func (auth *Authorization) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if auth.secretKey == nil {
-			next.ServeHTTP(rw, r)
+		if auth.secretKey != nil && !auth.verifySignature(rw, r) {
 			return
 		}
-
-		var err error
-
-		// backward compatibility: don't verify signature if it's not present in the request even if key is specified
-		reqSign, err := encrypt.GetSignature(r.Header)
-		if err != nil {
-			auth.logger.Warnw("Error getting signature", "error", err)
-			errorhandling.NewValidationHandlerError("can't read signature from incoming request").Render(rw)
+		if auth.trustedSubnet != nil && !auth.verifyClientIP(rw, r) {
 			return
 		}
-		if reqSign == nil {
-			next.ServeHTTP(rw, r)
-			return
-		}
-
-		var payload []byte
-		if r.Body != nil {
-			payload, err = io.ReadAll(r.Body)
-			if err != nil {
-				auth.logger.Warnw("can't read incoming request body for verification", "error", err)
-				errorhandling.NewValidationHandlerError("can't read incoming request body").Render(rw)
-				return
-			}
-		}
-
-		err = encrypt.CheckSignature(auth.secretKey, payload, reqSign)
-		if err != nil {
-			if errors.Is(err, encrypt.ErrSignatureInvalid) {
-				auth.logger.Debugw("incoming request signature is invalid")
-				rw.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-			auth.logger.Warnw("can't verify signature", "error", err)
-			errorhandling.NewInternalServerError(err).Render(rw)
-			return
-		}
-
-		r.Body = io.NopCloser(bytes.NewBuffer(payload))
 		next.ServeHTTP(rw, r)
 	})
+}
+
+// verifySignature checks signature header to contain client signature and if it's present, checks if it matches
+// a sign of a request body with a client secret key passed in parameters.
+// Returns true if sign is correct and false in case verification is failed and processing should be stopped.
+// In case of failure all corresponding information (headers, body) is written into response and should not be modified.
+func (auth *Authorization) verifySignature(rw http.ResponseWriter, r *http.Request) bool {
+	var err error
+
+	// backward compatibility: don't verify signature if it's not present in the request even if key is specified
+	reqSign, err := encrypt.GetSignature(r.Header)
+	if err != nil {
+		auth.logger.Warnw("Error getting signature", "error", err)
+		errorhandling.NewValidationHandlerError("can't read signature from incoming request").Render(rw)
+		return false
+	}
+	if reqSign == nil {
+		return true
+	}
+
+	var payload []byte
+	if r.Body != nil {
+		payload, err = io.ReadAll(r.Body)
+		if err != nil {
+			auth.logger.Warnw("can't read incoming request body for verification", "error", err)
+			errorhandling.NewValidationHandlerError("can't read incoming request body").Render(rw)
+			return false
+		}
+	}
+
+	err = encrypt.CheckSignature(auth.secretKey, payload, reqSign)
+	if err != nil {
+		if errors.Is(err, encrypt.ErrSignatureInvalid) {
+			auth.logger.Debugw("incoming request signature is invalid")
+			rw.WriteHeader(http.StatusUnauthorized)
+			return false
+		}
+		auth.logger.Warnw("can't verify signature", "error", err)
+		errorhandling.NewInternalServerError(err).Render(rw)
+		return false
+	}
+
+	// we need to re-write request body for further processing
+	r.Body = io.NopCloser(bytes.NewBuffer(payload))
+	return true
+}
+
+// verifyClientIP checks for X-Real-IP header of incoming request for valid IP address of a client and
+// then checks if it belongs to trustedSubnet.
+// Returns true if IP is trusted and false otherwise - in this case processing should be stopped.
+// In case of failure all corresponding information (headers, body) is written into response and should not be modified.
+func (auth *Authorization) verifyClientIP(rw http.ResponseWriter, r *http.Request) bool {
+	ipStr := r.Header.Get("X-Real-IP")
+	if ipStr == "" {
+		auth.logger.Debugw("X-Real-IP header of an incoming request is missing")
+		rw.WriteHeader(http.StatusUnauthorized)
+		return false
+	}
+
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		auth.logger.Debugw("X-Real-IP header of an incoming request is invalid")
+		rw.WriteHeader(http.StatusUnauthorized)
+		return false
+	}
+
+	subnet := ip.Mask(auth.trustedSubnet.Mask)
+	if !subnet.Equal(auth.trustedSubnet.IP) {
+		auth.logger.Debugw("X-Real-IP header of an incoming request is untrusted")
+		rw.WriteHeader(http.StatusUnauthorized)
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
Server updates:

- New configuration property (env: TRUSTED_SUBNET, flag -t) for specifying subnet in CIDR format
- If trusted subnet is specified, each incoming update metrics request is checked for `X-Real-IP` header which should contain IP address of a caller (or specified by proxy server) to belong to specified subnet
- Authorization middleware is refactored

Agent updates:

- `X-Real-IP` header is filled for each metrics send requests